### PR TITLE
Fix security: pin deploy workflow actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,10 +11,10 @@ jobs:
       contents: read
       deployments: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
 
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/wrangler-action@v3
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}


### PR DESCRIPTION
## Summary
- pin the production Cloudflare Pages deploy workflow actions to immutable commit SHAs
- remove mutable action tags from the secret-bearing deployment job

## Cloud Security finding addressed
- Unpinned deploy action can expose Cloudflare Pages token

## Verification
- git ls-remote confirmed actions/checkout@v4 resolves to 34e114876b0b11c390a56381ad16ebd13914f8d5
- git ls-remote confirmed cloudflare/wrangler-action@v3 resolves to 9acf94ace14e7dc412b076f2c5c20b8ce93c79cd
- rg found no mutable v/main/master/latest action refs in .github/workflows except a commented example
- git diff --check