### PR TITLE
Fix landing auto update deployment and static app fallback

### DIFF
--- a/.github/workflows/landing-auto-update.yml
+++ b/.github/workflows/landing-auto-update.yml
@@ -17,6 +17,7 @@ on:
 
 permissions:
   contents: write
+  deployments: write
 
 concurrency:
   group: landing-auto-update-${{ github.ref }}
@@ -52,6 +53,7 @@ jobs:
           python3 landing-automation/scripts/update_landing_data.py --event-file /tmp/landing-event.json
 
       - name: Commit changes
+        id: commit-changes
         env:
           TARGET_BRANCH: ${{ github.ref_name }}
           EVENT_NAME: ${{ github.event_name }}
@@ -61,6 +63,7 @@ jobs:
 
           if git diff --quiet; then
             echo "No changes"
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -70,6 +73,7 @@ jobs:
 
           if git diff --cached --quiet; then
             echo "No staged changes"
+            echo "changed=false" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
@@ -80,6 +84,7 @@ jobs:
           for attempt in 1 2 3; do
             if git push origin "HEAD:${TARGET_BRANCH}"; then
               echo "Push succeeded on attempt ${attempt}"
+              echo "changed=true" >> "${GITHUB_OUTPUT}"
               exit 0
             fi
 
@@ -101,8 +106,17 @@ jobs:
             git add data/landing-apps.generated.json landing-automation/state/landing_state.json assets/asc-screenshots
             if git diff --cached --quiet; then
               echo "No staged changes after refresh"
+              echo "changed=false" >> "${GITHUB_OUTPUT}"
               exit 0
             fi
             git commit -m "chore: auto update landing apps data"
             sleep $((attempt * 2))
           done
+
+      - name: Deploy to Cloudflare Pages
+        if: ${{ steps.commit-changes.outputs.changed == 'true' }}
+        uses: cloudflare/wrangler-action@9acf94ace14e7dc412b076f2c5c20b8ce93c79cd
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          command: pages deploy . --project-name=allnew-apps

--- a/index.html
+++ b/index.html
@@ -79,7 +79,7 @@
       "@type": "ItemList",
       "name": "AllNew iOS Apps",
       "description": "健康管理・ペットケア・生産性向上の iOS アプリカタログ",
-      "numberOfItems": 10,
+      "numberOfItems": 8,
       "itemListElement": [
         {
           "@type": "ListItem",
@@ -151,38 +151,6 @@
           "position": 5,
           "item": {
             "@type": "MobileApplication",
-            "name": "OxiSnap",
-            "alternateName": "血中酸素",
-            "description": "パルスオキシメーターを撮るだけ。SpO2 を自動認識して Apple HealthKit に記録。",
-            "url": "https://apps.allnew.work/oxisnap/",
-            "image": "https://apps.allnew.work/oxisnap-icon.png",
-            "applicationCategory": "HealthApplication",
-            "operatingSystem": "iOS",
-            "offers": { "@type": "Offer", "price": "0", "priceCurrency": "JPY" },
-            "author": { "@type": "Organization", "name": "AllNew LLC" }
-          }
-        },
-        {
-          "@type": "ListItem",
-          "position": 6,
-          "item": {
-            "@type": "MobileApplication",
-            "name": "BabyVox",
-            "alternateName": "Baby記録",
-            "description": "赤ちゃんの身長・体重・頭囲・胸囲を音声で入力。成長記録をカレンダーに保存。",
-            "url": "https://apps.allnew.work/babyvox/",
-            "image": "https://apps.allnew.work/babyvox-icon.png",
-            "applicationCategory": "HealthApplication",
-            "operatingSystem": "iOS",
-            "offers": { "@type": "Offer", "price": "0", "priceCurrency": "JPY" },
-            "author": { "@type": "Organization", "name": "AllNew LLC" }
-          }
-        },
-        {
-          "@type": "ListItem",
-          "position": 7,
-          "item": {
-            "@type": "MobileApplication",
             "name": "WaistVox",
             "alternateName": "ウエスト",
             "description": "ウエスト周囲径を声で言うだけ。音声認識で数値を自動抽出して Apple HealthKit に記録。",
@@ -196,7 +164,7 @@
         },
         {
           "@type": "ListItem",
-          "position": 8,
+          "position": 6,
           "item": {
             "@type": "MobileApplication",
             "name": "CoughWav",
@@ -212,7 +180,7 @@
         },
         {
           "@type": "ListItem",
-          "position": 9,
+          "position": 7,
           "item": {
             "@type": "MobileApplication",
             "name": "PupWeight",
@@ -228,7 +196,7 @@
         },
         {
           "@type": "ListItem",
-          "position": 10,
+          "position": 8,
           "item": {
             "@type": "MobileApplication",
             "name": "BOTTO",
@@ -1241,7 +1209,7 @@
                     <div class="method-number">01</div>
                     <h3 class="method-name" id="method-1-title">健康管理</h3>
                     <p class="method-label">Health</p>
-                    <p class="method-desc" id="method-1-desc">体重・体温・血圧・血糖値・SpO2・ウエスト周囲径。カメラ認識や音声入力で、毎日の健康データを Apple HealthKit にかんたん記録。</p>
+                    <p class="method-desc" id="method-1-desc">体重・体温・血圧・血糖値・ウエスト周囲径・咳の回数。カメラ認識や音声入力、音検出で、毎日の健康データを Apple HealthKit にかんたん記録。</p>
                 </div>
                 <div class="method-item">
                     <div class="method-number">02</div>
@@ -1272,7 +1240,7 @@
                 </div>
                 <div class="about-stats">
                     <div class="stat-item">
-                        <div class="stat-number" id="total-app-count">11</div>
+                        <div class="stat-number" id="total-app-count">8</div>
                         <p class="stat-label" id="stat-label-total-apps">Apps</p>
                     </div>
                     <div class="stat-item">
@@ -1399,42 +1367,6 @@
                         </div>
                         <span class="work-card-tag">Camera + OCR</span>
                         <p class="work-card-desc">血糖値計を撮るだけ。数値を自動認識して Apple HealthKit に記録。</p>
-                    </div>
-                    <div class="work-card-arrow"><svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M4.5 12L12 4.5M12 4.5H6M12 4.5V11"/></svg></div>
-                </a>
-
-                <a class="work-card" href="oxisnap/?lang=ja">
-                    <div class="work-card-img" style="background:#f5f5f5;">
-                        <img src="assets/onboarding/oxisnap-onboarding1.jpeg" alt="OxiSnap" loading="lazy">
-                    </div>
-                    <div class="work-card-body">
-                        <div class="work-card-meta">
-                            <img src="oxisnap-icon.png" alt="" class="work-card-icon">
-                            <div class="work-card-names">
-                                <div class="work-card-name">OxiSnap</div>
-                                <div class="work-card-ja">血中酸素</div>
-                            </div>
-                        </div>
-                        <span class="work-card-tag">Camera + OCR</span>
-                        <p class="work-card-desc">パルスオキシメーターを撮るだけ。SpO2 を自動認識して Apple HealthKit に記録。</p>
-                    </div>
-                    <div class="work-card-arrow"><svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M4.5 12L12 4.5M12 4.5H6M12 4.5V11"/></svg></div>
-                </a>
-
-                <a class="work-card" href="babyvox/?lang=ja">
-                    <div class="work-card-img" style="background:#f5f5f5;">
-                        <img src="assets/onboarding/babyvox-onboarding1.jpeg" alt="BabyVox" loading="lazy">
-                    </div>
-                    <div class="work-card-body">
-                        <div class="work-card-meta">
-                            <img src="babyvox-icon.png" alt="" class="work-card-icon">
-                            <div class="work-card-names">
-                                <div class="work-card-name">BabyVox</div>
-                                <div class="work-card-ja">Baby記録</div>
-                            </div>
-                        </div>
-                        <span class="work-card-tag">Voice Input</span>
-                        <p class="work-card-desc">赤ちゃんの身長・体重・頭囲・胸囲を音声で入力。成長記録をカレンダーに保存。*</p>
                     </div>
                     <div class="work-card-arrow"><svg viewBox="0 0 16 16" aria-hidden="true" focusable="false"><path d="M4.5 12L12 4.5M12 4.5H6M12 4.5V11"/></svg></div>
                 </a>
@@ -1597,7 +1529,7 @@
                 </div>
                 <div class="footer-col">
                     <p class="footer-col-title" id="footer-apps-title">Apps</p>
-                    <p id="footer-apps-health">Health: WeightSnap, ThermoSnap, BPSnap, GlucoSnap, OxiSnap, BabyVox, WaistVox, CoughWav</p>
+                    <p id="footer-apps-health">Health: WeightSnap, ThermoSnap, BPSnap, GlucoSnap, WaistVox, CoughWav</p>
                     <p id="footer-apps-pet">Pet: PupWeight</p>
                     <p id="footer-apps-productivity">Productivity: BOTTO</p>
                 </div>
@@ -1627,7 +1559,7 @@
                     'methods-section-title': '3つのカテゴリ',
                     'methods-section-text': '健康管理からペットケア、生産性向上まで。暮らしのあらゆるシーンをアプリでサポートします。',
                     'method-1-title': '健康管理',
-                    'method-1-desc': '体重・体温・血圧・血糖値・SpO2・ウエスト周囲径。カメラ認識や音声入力で、毎日の健康データを Apple HealthKit にかんたん記録。',
+                    'method-1-desc': '体重・体温・血圧・血糖値・ウエスト周囲径・咳の回数。カメラ認識や音声入力、音検出で、毎日の健康データを Apple HealthKit にかんたん記録。',
                     'method-2-title': 'ペットケア',
                     'method-2-desc': 'ペットの体重管理を音声でかんたんに。大切な家族の健康を、手間なく記録できます。',
                     'method-3-title': '生産性',
@@ -1680,7 +1612,7 @@
                     'methods-section-title': 'Three Categories',
                     'methods-section-text': 'From health tracking to pet care and productivity. Apps to support every part of your daily life.',
                     'method-1-title': 'Health',
-                    'method-1-desc': 'Weight, temperature, blood pressure, glucose, SpO2, waist circumference. Use camera recognition or voice input to log health data to Apple HealthKit effortlessly.',
+                    'method-1-desc': 'Weight, temperature, blood pressure, glucose, waist circumference, and cough count. Use camera recognition, voice input, or sound detection to log health data to Apple HealthKit effortlessly.',
                     'method-2-title': 'Pet Care',
                     'method-2-desc': 'Track your pet\'s weight with voice input. Keep your furry family member healthy with zero hassle.',
                     'method-3-title': 'Productivity',

--- a/landing-automation/scripts/update_landing_data.py
+++ b/landing-automation/scripts/update_landing_data.py
@@ -671,6 +671,8 @@ def update_from_event(
         print("[WARN] no app payload found in event")
         return existing_output, state
 
+    resolved_any = False
+
     for payload in payload_apps:
         slug = resolve_slug(payload, by_slug, by_bundle, by_app_id)
         if not slug:
@@ -681,6 +683,11 @@ def update_from_event(
         existing_entry = entries_by_slug.get(slug)
         entry = build_entry_from_event(existing_entry, catalog_entry, payload, event_data)
         entries_by_slug[slug] = entry
+        resolved_any = True
+
+    if not resolved_any:
+        print("[WARN] no resolvable app payload found in event")
+        return existing_output, state
 
     normalized_entries: list[dict[str, Any]] = []
     for slug, entry in entries_by_slug.items():


### PR DESCRIPTION
## Summary
- Ignore unresolved/empty ASC dispatch payloads so landing data/state are not rewritten as no-op noise.
- Deploy Cloudflare Pages directly from Landing Auto Update only after the workflow actually commits and pushes generated data.
- Align the static HTML/JSON-LD fallback with the generated 8-app catalog by removing OxiSnap and BabyVox from non-JS surfaces.

## Verification
- python3 -m py_compile landing-automation/scripts/update_landing_data.py
- Parsed .github/workflows/deploy.yml and .github/workflows/landing-auto-update.yml with PyYAML
- Simulated empty asc_status_changed payload: changed=false, output/state unchanged
- Parsed index.html JSON-LD: numberOfItems=8
- git diff --check HEAD~2..HEAD

## Ops notes
- Cloudflare Wrangler OAuth login succeeded without reading token values.
- Worker allnew-asc-webhook-relay is deployed and has secret names ASC_WEBHOOK_SECRET, ASC_WEBHOOK_SECRET_PREVIOUS, and GITHUB_TOKEN configured.
- Cloudflare Pages production deployments exist for allnew-apps; latest deployment source before this PR was 957f7f3.