### PR TITLE
Run Wrangler deploys on Node 24

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,9 +13,18 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: landing-automation/cloudflare-worker/package-lock.json
+
       - name: Install Wrangler
         working-directory: landing-automation/cloudflare-worker
-        run: npm ci
+        run: |
+          node --version
+          npm ci
 
       - name: Deploy to Cloudflare Pages
         working-directory: landing-automation/cloudflare-worker

--- a/.github/workflows/landing-auto-update.yml
+++ b/.github/workflows/landing-auto-update.yml
@@ -125,10 +125,20 @@ jobs:
             sleep $((attempt * 2))
           done
 
+      - name: Setup Node
+        if: ${{ steps.commit-changes.outputs.changed == 'true' }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "24"
+          cache: npm
+          cache-dependency-path: landing-automation/cloudflare-worker/package-lock.json
+
       - name: Install Wrangler
         if: ${{ steps.commit-changes.outputs.changed == 'true' }}
         working-directory: landing-automation/cloudflare-worker
-        run: npm ci
+        run: |
+          node --version
+          npm ci
 
       - name: Deploy to Cloudflare Pages
         if: ${{ steps.commit-changes.outputs.changed == 'true' }}


### PR DESCRIPTION
## Summary
- add actions/setup-node v6.4.0 pinned by SHA before Wrangler deploy paths
- set the runtime Node version to 24 for Pages deploys
- print node --version before npm ci so Actions logs show the runtime version used by Wrangler

## Root cause
The previous Node 24 action migration removed the Node 20-backed Cloudflare action, but the direct npx wrangler step still used the GitHub runner default Node v20.20.2. Wrangler 4.88.0 requires Node >=22, so the main deploy failed before upload.

## Validation
- ruby YAML parse for deploy, landing-auto-update, reusable-landing-sync
- npm ci in landing-automation/cloudflare-worker
- npx wrangler --version -> 4.88.0
- npm audit --audit-level=high
- npx wrangler deploy --dry-run
