### PR TITLE
Deploy Pages from repository root

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,8 +27,7 @@ jobs:
           npm ci
 
       - name: Deploy to Cloudflare Pages
-        working-directory: landing-automation/cloudflare-worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler pages deploy ../.. --project-name=allnew-apps
+        run: landing-automation/cloudflare-worker/node_modules/.bin/wrangler pages deploy . --project-name=allnew-apps

--- a/.github/workflows/landing-auto-update.yml
+++ b/.github/workflows/landing-auto-update.yml
@@ -142,8 +142,7 @@ jobs:
 
       - name: Deploy to Cloudflare Pages
         if: ${{ steps.commit-changes.outputs.changed == 'true' }}
-        working-directory: landing-automation/cloudflare-worker
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-        run: npx wrangler pages deploy ../.. --project-name=allnew-apps
+        run: landing-automation/cloudflare-worker/node_modules/.bin/wrangler pages deploy . --project-name=allnew-apps


### PR DESCRIPTION
## Summary
- keep Wrangler installed from the worker package
- run Pages deploy from the repository root via the local Wrangler binary
- avoid Wrangler treating the Worker wrangler.toml as a Pages config

## Why
The Node 24 deploy succeeded, but Wrangler emitted a Pages config warning because the deploy step ran from landing-automation/cloudflare-worker where the Worker wrangler.toml lives. Deploying from the repository root preserves the same upload target while removing that warning source.

## Validation
- ruby YAML parse for deploy, landing-auto-update, reusable-landing-sync
- verified local Wrangler binary path resolves to 4.88.0
