### PR TITLE
Update landing page checks Playwright

### DIFF
--- a/landing-automation/tools/lp-checks/package-lock.json
+++ b/landing-automation/tools/lp-checks/package-lock.json
@@ -1,0 +1,67 @@
+{
+  "name": "allnew-lp-checks",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "allnew-lp-checks",
+      "dependencies": {
+        "axe-core": "4.9.1",
+        "playwright": "1.59.1"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.9.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.9.1.tgz",
+      "integrity": "sha512-QbUdXJVTpvUTHU7871ppZkdOLBeGUKBQWHkHrvN2V9IQWGMt61zf3B45BtzjxEJzYuj0JBjBZP/hmYS/R9pmAw==",
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/landing-automation/tools/lp-checks/package.json
+++ b/landing-automation/tools/lp-checks/package.json
@@ -8,7 +8,6 @@
   },
   "dependencies": {
     "axe-core": "4.9.1",
-    "playwright": "1.49.1"
+    "playwright": "1.59.1"
   }
 }
-


### PR DESCRIPTION
## Summary
- update landing page check tooling from playwright 1.49.1 to 1.59.1
- add a package-lock for reproducible audit/install in lp-checks

## Why
Dependabot still reported one high vulnerability on the default branch: playwright < 1.55.1 in landing-automation/tools/lp-checks/package.json.

## Validation
- npm ci --ignore-scripts in landing-automation/tools/lp-checks
- npm audit --audit-level=high in landing-automation/tools/lp-checks
- verified package-lock resolves playwright 1.59.1
