### PR TITLE
Deploy GitHub Pages with Node 24 actions

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,0 +1,38 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: github-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: .
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0


### PR DESCRIPTION
## Summary
- add an explicit GitHub Pages deployment workflow
- pin Pages actions to current Node 24-backed releases by SHA
- keep the existing GitHub Pages URL available without relying on legacy branch builds

## Why
The repository still had GitHub Pages enabled in legacy branch mode. That dynamic pages-build-deployment job emitted Node.js 20 deprecation warnings from GitHub-managed actions.

## Validation
- ruby YAML parse for .github/workflows/github-pages.yml
- verified actions/checkout v6, actions/configure-pages v6, actions/deploy-pages v5 use Node 24; upload-pages-artifact v5 delegates to upload-artifact v7
