### PR TITLE
Refresh PocketLuma hosted legal page

### DIFF
--- a/pocketluma/index.html
+++ b/pocketluma/index.html
@@ -20,9 +20,12 @@
       --bg: #fafafa; --panel: #ffffff; --muted: #6e6e73; --text: #1d1d1f;
       --accent: #0071e3; --border: rgba(0,0,0,.08); --glass: rgba(255,255,255,.78);
       --radius: 20px; --shadow: 0 10px 30px rgba(0,0,0,.06);
+      --bg-secondary: #f5f5f7; --bg-tertiary: #fbfbfd; --text-secondary: #6e6e73;
+      --text-tertiary: #8e8e93; --text-primary: #1d1d1f; --accent-hover: #0066cc;
+      --radius-sm: 16px; --radius-lg: 28px;
     }
     @media (prefers-color-scheme: dark) {
-      :root { --bg: #000; --panel: #1c1c1e; --muted: #a1a1a6; --text: #f5f5f7; --border: rgba(255,255,255,.12); --glass: rgba(28,28,30,.78); }
+      :root { --bg: #000; --panel: #1c1c1e; --muted: #a1a1a6; --text: #f5f5f7; --border: rgba(255,255,255,.12); --glass: rgba(28,28,30,.78); --bg-secondary: #1c1c1e; --bg-tertiary: #2c2c2e; --text-secondary: #a1a1a6; --text-tertiary: #8e8e93; --text-primary: #f5f5f7; }
     }
     * { box-sizing: border-box; }
     html { scroll-behavior: smooth; }
@@ -45,9 +48,42 @@
     table { width: 100%; border-collapse: collapse; margin: 14px 0; overflow-wrap: anywhere; }
     th, td { border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; padding: 9px 6px; }
     .muted { color: var(--muted); }
+    .section-header { display: flex; align-items: center; gap: 14px; margin-bottom: 18px; }
+    .section-icon { width: 44px; height: 44px; border-radius: 14px; background: var(--bg-secondary); display: flex; align-items: center; justify-content: center; flex-shrink: 0; }
+    .section-title { font-size: 1.45rem; line-height: 1.2; font-weight: 750; letter-spacing: -.015em; }
+    .section-subtitle { color: var(--muted); font-size: .9rem; margin-top: 2px; }
+    .legal-section h3 { margin: 22px 0 8px; font-size: 1.05rem; }
+    .legal-section p { color: var(--text-secondary); font-size: .93rem; }
+    .legal-section ul { color: var(--text-secondary); font-size: .93rem; }
+    .commercial-accordion { background: var(--bg-secondary); border-radius: var(--radius-sm); border: 1px solid var(--border); overflow: hidden; }
+    .commercial-header { width: 100%; appearance: none; border: 0; background: transparent; color: inherit; display: flex; align-items: center; justify-content: space-between; padding: 20px 24px; cursor: pointer; text-align: left; transition: background .2s ease; }
+    .commercial-header:hover { background: var(--bg-tertiary); }
+    .commercial-header .section-header { margin-bottom: 0; }
+    .commercial-toggle { width: 28px; height: 28px; border-radius: 50%; background: var(--bg-tertiary); display: flex; align-items: center; justify-content: center; color: var(--accent); font-size: 20px; font-weight: 300; transition: all .25s ease; flex-shrink: 0; }
+    .commercial-accordion.open .commercial-toggle { background: var(--accent); color: white; transform: rotate(45deg); }
+    .commercial-content { max-height: 0; overflow: hidden; transition: max-height .28s ease; }
+    .commercial-accordion.open .commercial-content { max-height: 1400px; padding: 0 24px 24px; }
+    .contact-card { background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%); border-radius: var(--radius-lg); padding: 40px; text-align: center; border: 1px solid var(--border); }
+    .contact-card h2 { font-size: 1.4rem; font-weight: 700; margin: 0 0 22px; }
+    .contact-email { display: inline-flex; align-items: center; gap: 10px; background: var(--accent); color: white; padding: 14px 28px; border-radius: 980px; text-decoration: none; font-weight: 650; font-size: .95rem; transition: all .2s ease; }
+    .contact-email:hover { background: var(--accent-hover); transform: scale(1.02); text-decoration: none; }
+    .contact-details { margin-top: 32px; padding-top: 24px; border-top: 1px solid var(--border); text-align: left; display: grid; grid-template-columns: repeat(auto-fit, minmax(180px, 1fr)); gap: 16px; }
+    .contact-details-top { margin-top: 24px; margin-bottom: 24px; padding-top: 0; padding-bottom: 16px; border-top: none; border-bottom: 1px solid var(--border); }
+    .contact-item { font-size: .88rem; }
+    .contact-item dt { color: var(--text-tertiary); font-weight: 650; margin-bottom: 4px; }
+    .contact-item dd { color: var(--text-primary); margin: 0; overflow-wrap: anywhere; }
     [data-lang="en"] { display: none; }
     body.lang-en [data-lang="ja"] { display: none; }
     body.lang-en [data-lang="en"] { display: block; }
+    @media (max-width: 640px) {
+      main { padding: 30px 16px 70px; }
+      section { padding: 18px; }
+      .section-header { flex-direction: column; text-align: center; }
+      .commercial-header { padding: 18px; }
+      .commercial-header .section-header { flex-direction: row; text-align: left; }
+      .contact-card { padding: 28px; }
+      .contact-details { grid-template-columns: 1fr; }
+    }
   </style>
 </head>
 <body>
@@ -87,13 +123,13 @@
 </nav>
     <section id="faq-ja" data-lang="ja"><h2>FAQ</h2><h3>このページで確認できる内容は？</h3><p>FAQ、プライバシーポリシー、利用規約、特定商取引法に基づく表記、お問い合わせ方法を確認できます。</p><h3>データはどこで処理されますか？</h3><p>ユーザーデータは原則として端末内で処理され、当社の外部サーバーへ送信・保存されません。</p><h3>問い合わせ先は？</h3><p>サポート窓口は <!--email_off-->app-support@allnew.work<!--/email_off--> です。</p></section>
     <section id="faq-en" data-lang="en"><h2>FAQ</h2><h3>What can I find here?</h3><p>This page includes FAQ, Privacy Policy, Terms of Service, commercial disclosure, and contact details.</p><h3>Where is data processed?</h3><p>User data is processed on device by default and is not sent to or stored on AllNew servers.</p><h3>How can I contact support?</h3><p>Please contact <!--email_off-->app-support@allnew.work<!--/email_off-->.</p></section>
-    <section id="privacy-ja" data-lang="ja"><h2>プライバシーポリシー</h2><p>最終更新日: 2026-05-07</p>
-<p>**重要:** 本アプリは、ヘルスケアデータを当社の外部サーバーへ送信・保存しません。</p>
+    <section id="privacy-ja" class="section" data-lang="ja"><div class="section-header"><div class="section-icon">🔒</div><div><div class="section-title">プライバシーポリシー</div><div class="section-subtitle">データの取り扱い</div></div></div><div class="legal-section"><p>最終更新日: 2026-05-07</p>
+<p>**重要:** 本アプリは、ユーザーデータを当社の外部サーバーへ送信・保存しません。</p>
 <p>合同会社AllNew（以下「当社」）は、本アプリにおけるユーザー情報の取り扱いについて本ポリシーを定めます。当社の名称、住所、代表者等の事業者情報は、特定商取引法に基づく表示をご確認ください。</p>
 <h3>1. 取り扱う情報</h3>
 <p>当社は、本アプリを提供するために、次の情報を取り扱う場合があります。</p>
-<h3>(A) ヘルスケア（Apple Health）データ</h3>
-<ul><li>本アプリは、ユーザーの許可に基づき、（該当なし）をヘルスケアへ行います。</li><li>本アプリは、ユーザーが任意に許可した場合に限り、ヘルスケア上のデータを読み取り、（該当なし）に利用します。</li><li>当社は、ヘルスケアデータを当社が運用する外部サーバーへ送信・保存しません。</li></ul>
+<h3>(A) 端末内データ</h3>
+<ul><li>本アプリで作成、撮影、保存、管理されるデータは、ユーザーの端末内で処理されます。</li><li>当社は、当該データを当社が運用する外部サーバーへ送信・保存しません。</li></ul>
 <h3>(B) カメラ画像（撮影画像）</h3>
 <ul><li>本アプリはカメラは、ユーザーが明示的に操作した撮影・プレビュー機能のためにのみ使用します。撮影画像は端末内で処理され、法務文書生成や外部サーバー送信には使用しません。</li><li>当社は撮影画像を当社が運用する外部サーバーへ送信・保存しません。</li></ul>
 <h3>(C) お問い合わせ情報（サポート）</h3>
@@ -104,15 +140,15 @@
 <p>当社は、上記情報を以下の目的で利用します。</p>
 <ul><li>本アプリの機能提供（ポケットサイズのレトロカメラ）</li><li>サポート対応、問い合わせへの返信</li><li>不具合調査・品質改善（ユーザーが提供した範囲に限る）</li><li>法令遵守・紛争対応</li></ul>
 <h3>3. 第三者提供・外部送信</h3>
-<ul><li>当社は、（当社が収集する個人データはありません）、ヘルスケアから読み取ったデータ、および撮影画像を、当社が運用する外部サーバーへ送信・保存しません。</li><li>当社は、お問い合わせ情報等を、ユーザーの同意なく第三者へ提供しません。ただし、法令に基づく場合等を除きます。</li><li>ヘルスケアデータの保存・同期（iCloud等）やApple側処理の挙動は、ユーザーの端末設定およびAppleの仕様に従います。当社はAppleの挙動を制御できません。</li><li>当社は、（当社が収集する個人データはありません）を広告・マーケティング・プロファイリング目的で利用せず、第三者へ販売・貸与等もしません。</li><li>当社はiOSアプリ内に解析SDK（アナリティクスSDK）を導入していません。</li><li>本ウェブサイトでは、Vercel Web Analyticsを使用しています。Vercel Web AnalyticsはCookieを使用せず、個人を特定する情報を収集しません。ページビュー数、参照元、デバイスの種類などの集計データのみを収集します。</li></ul>
+<ul><li>当社は、（当社が収集する個人データはありません）、端末内で処理されるデータ、および撮影画像を、当社が運用する外部サーバーへ送信・保存しません。</li><li>当社は、お問い合わせ情報等を、ユーザーの同意なく第三者へ提供しません。ただし、法令に基づく場合等を除きます。</li><li>当社は、（当社が収集する個人データはありません）を広告・マーケティング・プロファイリング目的で利用せず、第三者へ販売・貸与等もしません。</li><li>当社は、ユーザーの端末内データを広告・マーケティング・プロファイリング目的で利用せず、第三者へ販売・貸与等もしません。</li><li>写真、ファイル、iCloud等の保存・同期は、ユーザーの端末設定およびAppleの仕様に従います。当社はAppleの挙動を制御できません。</li><li>当社はiOSアプリ内に解析SDK（アナリティクスSDK）を導入していません。</li><li>本ウェブサイトでは、Vercel Web Analyticsを使用しています。Vercel Web AnalyticsはCookieを使用せず、個人を特定する情報を収集しません。ページビュー数、参照元、デバイスの種類などの集計データのみを収集します。</li></ul>
 <h3>4. 保管期間</h3>
-<ul><li>お問い合わせ情報は、原則として対応完了後12か月以内に削除します。</li><li>ただし、未解決の問い合わせ、紛争対応、法令上の保存義務がある場合は、必要な期間保管する場合があります。</li><li>ヘルスケアデータはユーザーの端末およびヘルスケア上で管理され、当社は当社サーバー上に保管しません。</li></ul>
+<ul><li>お問い合わせ情報は、原則として対応完了後12か月以内に削除します。</li><li>ただし、未解決の問い合わせ、紛争対応、法令上の保存義務がある場合は、必要な期間保管する場合があります。</li><li>本アプリで作成、撮影、保存、管理されるデータはユーザーの端末上で管理され、当社は当社サーバー上に保管しません。</li></ul>
 <h3>5. セキュリティ</h3>
-<p>当社は、お問い合わせ対応等で取り扱う情報について、合理的な安全管理措置を講じます。ヘルスケアデータはAppleの仕組みにより保護されます（詳細はユーザーの端末設定およびAppleの仕様に依存します）。</p>
+<p>当社は、お問い合わせ対応等で取り扱う情報について、合理的な安全管理措置を講じます。端末内データは、iOSおよびAppleの仕組みにより保護されます（詳細はユーザーの端末設定およびAppleの仕様に依存します）。</p>
 <h3>6. ユーザーの権利</h3>
 <p>当社が保有するお問い合わせ情報等について、ユーザーは、適用法令の範囲で、開示・訂正・削除等を求めることができます。ご希望は「9. お問い合わせ」へご連絡ください。</p>
-<p>※当社はヘルスケアデータを保有しないため、ヘルスケア上のデータはヘルスケアアプリ等で管理・削除してください。</p>
-<ul><li>**すべてのユーザー:** HealthKitデータの管理・削除はiOSのApple Health（ヘルスケア）アプリから可能です。表示項目はiOSバージョンにより異なる場合があります。アプリ削除時、iOSがヘルスケアデータの削除を確認します。</li><li>**EU/EEA居住者（GDPR）:** 苦情申立て権、同意の撤回権。</li><li>**カリフォルニア州居住者（CCPA/CPRA）:** 知る権利、削除権、オプトアウト権。</li><li>**中国居住者（PIPL）:** 知る権利、閲覧・複製権、削除権。当社はユーザーデータを当社の外部サーバーへ移転しません。ただし、HealthKitの同期（iCloud等）等、Appleのサービスにより、ユーザーの国・地域外で処理／保存される可能性があります。</li><li>**韓国居住者（PIPA）:** 処理中止要求権。</li><li>**ブラジル居住者（LGPD）:** データ移行要求権。</li></ul>
+<p>※当社は端末内データを当社サーバー上に保有しないため、写真、ファイル、アプリ内データ等はユーザーの端末上で管理・削除してください。</p>
+<ul><li>**すべてのユーザー:** 端末内データの管理・削除は、本アプリ、iOSの写真アプリ、ファイルアプリ、またはiOS設定から行えます。表示項目はiOSバージョンにより異なる場合があります。</li><li>**EU/EEA居住者（GDPR）:** 苦情申立て権、同意の撤回権。</li><li>**カリフォルニア州居住者（CCPA/CPRA）:** 知る権利、削除権、オプトアウト権。</li><li>**中国居住者（PIPL）:** 知る権利、閲覧・複製権、削除権。当社はユーザーデータを当社の外部サーバーへ移転しません。ただし、iCloud等のAppleサービスにより、ユーザーの国・地域外で処理／保存される可能性があります。</li><li>**韓国居住者（PIPA）:** 処理中止要求権。</li><li>**ブラジル居住者（LGPD）:** データ移行要求権。</li></ul>
 <h3>7. 子どものプライバシー</h3>
 <p>本アプリは13歳未満（または居住国の最低年齢）の子どもを対象としていません。</p>
 <h3>8. 改定</h3>
@@ -125,14 +161,14 @@
 <p>本プライバシーポリシーは日本語を正文とします。他言語版との間に矛盾がある場合、日本語版を優先します。ただし、この規定は各居住国・地域の消費者保護法その他の強行法規に基づくユーザーの権利を制限するものではありません。</p>
 <p>---</p>
 <p>運営: 合同会社AllNew</p>
-<p>Apple、iPhone、iOS、Apple Health、HealthKitは、米国およびその他の国で登録されたApple Inc.の商標です。その他の会社名・製品名は各社の商標または登録商標です。</p>
-<p>© 2026 合同会社AllNew</p></section>
-    <section id="privacy-en" data-lang="en"><h2>Privacy Policy</h2><p>Last Updated: 2026-05-07</p>
-<p>**Important:** This app does not transmit or store your Apple Health data on our servers.</p>
+<p>Apple、iPhone、iOS、App Store、iCloudは、米国およびその他の国で登録されたApple Inc.の商標です。その他の会社名・製品名は各社の商標または登録商標です。</p>
+<p>© 2026 合同会社AllNew</p></div></section>
+    <section id="privacy-en" class="section" data-lang="en"><div class="section-header"><div class="section-icon">🔒</div><div><div class="section-title">Privacy Policy</div><div class="section-subtitle">Data handling</div></div></div><div class="legal-section"><p>Last Updated: 2026-05-07</p>
+<p>**Important:** This app does not transmit or store user data on our servers.</p>
 <p>This Privacy Policy explains how AllNew LLC (&quot;we&quot;) handles information in the 80&#x27;s Camera app. For our company name, address, and representative details, please refer to our Legal Notice (Specified Commercial Transactions Act disclosure).</p>
 <h3>1. Information We Handle</h3>
-<h3>(A) Apple Health data</h3>
-<ul><li>With your permission, the App performs (not applicable) to the Apple Health app (via HealthKit).</li><li>If you optionally grant read access, the App may use (not applicable).</li><li>We do not transmit or store Apple Health data on servers operated by us.</li></ul>
+<h3>(A) On-device data</h3>
+<ul><li>Data created, captured, saved, or managed in the App is processed on your device.</li><li>We do not transmit or store that data on servers operated by us.</li></ul>
 <h3>(B) Camera images</h3>
 <ul><li>The App uses the camera only for user-initiated capture and preview features. Captured images are processed on device and are not used for legal document generation or uploaded to AllNew servers..</li><li>We do not transmit or store captured images on servers operated by us.</li></ul>
 <h3>(C) Support communications</h3>
@@ -143,15 +179,15 @@
 <p>We use information only to:</p>
 <ul><li>Provide app functionality (Pocket-sized retro film camera)</li><li>Respond to support requests</li><li>Troubleshoot issues (based on what you provide)</li><li>Comply with law</li></ul>
 <h3>3. Sharing &amp; Apple Services</h3>
-<ul><li>We do not use Apple Health data for advertising, marketing profiling, or data brokerage, and we do not sell such data.</li><li>We do not transmit or store your (we do not collect personal data), Apple Health read data, captured images, or motion data on servers operated by us.</li><li>Apple Health storage/sync (including iCloud) and Apple-side processing depend on your device settings and Apple&#x27;s system behavior. We do not control Apple&#x27;s behavior.</li><li>We do not use any analytics SDK in the iOS App.</li><li>This website uses Vercel Web Analytics. Vercel Web Analytics is cookie-free and does not collect personally identifiable information. It only collects aggregate data such as page views, referrers, and device types.</li></ul>
+<ul><li>We do not transmit or store your (we do not collect personal data), on-device data, captured images, or motion data on servers operated by us.</li><li>We do not use on-device user data for advertising, marketing profiling, or data brokerage, and we do not sell such data.</li><li>Photo, file, iCloud, and other storage/sync behavior depends on your device settings and Apple&#x27;s system behavior. We do not control Apple&#x27;s behavior.</li><li>We do not use any analytics SDK in the iOS App.</li><li>This website uses Vercel Web Analytics. Vercel Web Analytics is cookie-free and does not collect personally identifiable information. It only collects aggregate data such as page views, referrers, and device types.</li></ul>
 <h3>4. Retention</h3>
-<ul><li>Support emails are retained for up to 12 months after resolution, unless longer retention is required for disputes or legal obligations.</li><li>We do not retain Apple Health data on our servers.</li></ul>
+<ul><li>Support emails are retained for up to 12 months after resolution, unless longer retention is required for disputes or legal obligations.</li><li>Data created, captured, saved, or managed in the App is stored on your device. We do not retain it on our servers.</li></ul>
 <h3>5. Security</h3>
-<p>We employ reasonable security measures for support communications we handle. HealthKit data is protected by Apple&#x27;s systems (details depend on your device settings and Apple&#x27;s specifications).</p>
+<p>We employ reasonable security measures for support communications we handle. On-device data is protected by iOS and Apple&#x27;s systems (details depend on your device settings and Apple&#x27;s specifications).</p>
 <h3>6. Your Rights</h3>
 <p>Where applicable, you may request access, correction, or deletion of support information we hold. Contact us via &quot;9. Contact&quot; below.</p>
-<p>Note: Apple Health data should be managed in the Apple Health app since we do not retain it.</p>
-<ul><li>**All Users:** You can manage or delete HealthKit data through the iOS Apple Health app. Navigation paths may vary depending on your iOS version. When uninstalling, iOS asks whether to delete health data.</li><li>**EU/EEA (GDPR):** Right to lodge complaints, withdraw consent.</li><li>**California (CCPA/CPRA):** Right to know, delete, opt-out. We don&#x27;t sell personal information.</li><li>**China (PIPL):** Right to know, access, correct, delete. We do not transfer your data to our external servers. However, depending on your Apple/iCloud settings and Apple services (e.g., iCloud sync), data may be processed or stored outside your country/region.</li><li>**South Korea (PIPA):** Right to request processing suspension.</li><li>**Brazil (LGPD):** Right to data portability.</li></ul>
+<p>Note: Since we do not retain on-device data on our servers, please manage or delete photos, files, and app data on your device.</p>
+<ul><li>**All Users:** You can manage or delete on-device data through the App, iOS Photos, Files, or iOS Settings. Navigation paths may vary depending on your iOS version.</li><li>**EU/EEA (GDPR):** Right to lodge complaints, withdraw consent.</li><li>**California (CCPA/CPRA):** Right to know, delete, opt-out. We don&#x27;t sell personal information.</li><li>**China (PIPL):** Right to know, access, correct, delete. We do not transfer your data to our external servers. However, depending on your Apple/iCloud settings and Apple services (e.g., iCloud sync), data may be processed or stored outside your country/region.</li><li>**South Korea (PIPA):** Right to request processing suspension.</li><li>**Brazil (LGPD):** Right to data portability.</li></ul>
 <h3>7. Children&#x27;s Privacy</h3>
 <p>This App is not intended for children under 13 (or the minimum age in your country of residence).</p>
 <h3>8. Changes to This Policy</h3>
@@ -164,92 +200,80 @@
 <p>The Japanese version of this Privacy Policy is the authoritative text. In case of any conflict between translated versions and the Japanese version, the Japanese version shall prevail. However, this does not limit your rights under mandatory consumer protection laws or other applicable regulations in your country or region of residence.</p>
 <p>---</p>
 <p>Operator: AllNew LLC</p>
-<p>Apple, iPhone, iOS, Apple Health, and HealthKit are trademarks of Apple Inc., registered in the U.S. and other countries. Other company and product names may be trademarks of their respective owners.</p>
-<p>© 2026 AllNew LLC</p></section>
-    <section id="terms-ja" data-lang="ja"><h2>利用規約</h2><p>最終更新日: 2026-05-07</p>
-<p>本利用規約（以下「本規約」）は、合同会社AllNew（以下「当社」）が提供するiOSアプリ「80&#x27;s Camera」（以下「本アプリ」）の利用条件を定めるものです。</p>
-<h3>1. 同意</h3>
-<p>ユーザーは、本アプリをダウンロード、インストール、または利用した時点で、本規約に同意したものとみなされます。同意しない場合は利用しないでください。</p>
-<h3>2. サービス概要</h3>
-<p>本アプリは、App Store記載内容およびアプリ内説明に基づく機能を提供します。機能の提供状況は、端末環境、地域、権限設定、プラットフォームポリシー等により異なる場合があります。</p>
-<h3>3. 利用資格・アカウント</h3>
-<p>ユーザーは、適用法令およびプラットフォーム規約を遵守して本アプリを利用するものとします。アカウント機能がある場合、認証情報の管理責任はユーザーにあります。</p>
-<h3>4. 無料提供・課金なし</h3>
-<p>本アプリは無料で提供され、アプリ内課金、定期購読、有料機能はありません。将来、有料機能を追加する場合は、App Store上の表示、本規約、および法務ページを更新します。</p>
-<h3>5. 利用許諾</h3>
-<p>当社は、ユーザーに対し、本規約に従うことを条件として、本アプリを適法な目的で利用するための限定的・非独占的・譲渡不能・取消可能な使用権を付与します。</p>
-<h3>6. 禁止事項</h3>
+<p>Apple, iPhone, iOS, App Store, and iCloud are trademarks of Apple Inc., registered in the U.S. and other countries. Other company and product names may be trademarks of their respective owners.</p>
+<p>© 2026 AllNew LLC</p></div></section>
+    <section id="terms-ja" class="section" data-lang="ja"><div class="section-header"><div class="section-icon">📜</div><div><div class="section-title">利用規約</div><div class="section-subtitle">サービスのご利用条件</div></div></div><div class="legal-section"><p>最終更新日: 2026-05-07</p>
+<h3>1. 規約の適用</h3>
+<p>本利用規約（以下「本規約」といいます）は、合同会社AllNew（以下「当社」といいます）が提供するiOSアプリケーション「80&#x27;s Camera」（以下「本アプリ」といいます）の利用条件を定めるものです。ユーザーは本規約に同意した上で本アプリを利用するものとします。</p>
+<h3>2. 利用開始と同意</h3>
+<p>ユーザーが本アプリをダウンロードし、インストールまたは利用を開始した時点で、本規約に同意したものとみなされます。本規約に同意しない場合、本アプリをご利用いただくことはできません。</p>
+<h3>3. 本アプリの概要と対応機器</h3>
+<p>本アプリは、App Store記載内容およびアプリ内説明に基づき、ポケットサイズのレトロカメラを提供するアプリケーションです。カメラは、ユーザーが明示的に操作した撮影・プレビュー機能のためにのみ使用します。撮影画像は端末内で処理され、法務文書生成や外部サーバー送信には使用しません。</p>
+<ul><li>対応デバイス: iOS 17.0以降を搭載したiPhone</li><li>対応OSや提供機能は、端末環境、地域、権限設定、プラットフォームポリシー等により異なる場合があります</li><li>本アプリは、ユーザーが自ら入力、撮影、保存、管理する内容を補助するものであり、当社が当該内容の正確性や完全性を保証するものではありません</li></ul>
+<h3>4. プライバシーポリシーおよびデータの取り扱い</h3>
+<p>当社は、本アプリの利用に関連して取り扱う情報を別途定めるプライバシーポリシーに従って取り扱います。</p>
+<p>ユーザーが本アプリで作成、撮影、保存、管理するデータについて、当社は以下を遵守します。</p>
+<ul><li>プライバシーポリシーで明示した場合を除き、ユーザーのデータを広告、マーケティング、またはデータマイニング目的で使用しません</li><li>ユーザーのデータをデータブローカーや第三者に販売・提供しません</li><li>端末内処理を前提とする機能について、ユーザーのデータを当社が運用するサーバーへ送信・保存しません</li></ul>
+<h3>5. 禁止事項</h3>
 <p>ユーザーは、以下の行為をしてはなりません。</p>
-<ul><li>法令違反、公序良俗違反、第三者権利侵害</li><li>リバースエンジニアリング、不正アクセス、サービス妨害</li><li>不正利用、詐欺、嫌がらせ、悪質行為</li><li>違法・権利侵害・有害コンテンツの送信または掲載</li></ul>
-<h3>7. 知的財産権</h3>
-<p>本アプリおよび関連資料に関する知的財産権は、当社またはライセンサーに帰属します。本規約により権利の移転は生じません。</p>
-<h3>8. プライバシー</h3>
-<p>情報の取扱いは別途定めるプライバシーポリシーに従います。ユーザーは本アプリの利用により、同ポリシー記載の処理を認識したものとします。</p>
-<h3>9. 提供内容の変更・停止</h3>
-<p>当社は、法令で許容される範囲で、本アプリの全部または一部を変更、制限、停止、終了することがあります。</p>
-<h3>10. 免責・責任制限</h3>
-<p>1. 当社は、本アプリがユーザーの特定目的に適合すること、誤認識が発生しないこと、完全性・正確性・有用性等を保証しません。 2. 当社は、ユーザーの端末、OS、Appleのサービス（ヘルスケア、iCloud等）の仕様や障害に起因する損害について責任を負いません。 3. 当社が責任を負う場合でも、当社の故意または重過失がある場合を除き、当社の責任は通常かつ直接の損害に限られます。なお、消費者契約法その他の強行法規により制限される範囲では本項は適用されません。</p>
-<h3>11. 補償</h3>
-<p>ユーザーの法令違反または本規約違反に起因して当社に損害が生じた場合、ユーザーはこれを補償するものとします。</p>
-<h3>12. 利用停止・終了</h3>
-<p>ユーザーが本規約、法令、またはプラットフォーム要件に重大に違反した場合、当社は利用停止または終了措置をとることがあります。</p>
-<h3>13. 規約変更</h3>
-<p>当社は、必要に応じて本規約を変更できます。変更後の規約は当社サイト等での掲示により効力を生じます。重要な変更の場合は合理的な方法で事前告知に努めます。</p>
-<h3>14. Appleに関する条項</h3>
-<p>本規約はユーザーと当社の間で成立し、Appleは当事者ではありません。保守・サポート責任は当社が負います。必要な範囲でAppleおよびその子会社は第三者受益者となる場合があります。</p>
-<h3>15. 準拠法・管轄</h3>
-<p>法令に別段の定めがある場合を除き、本規約は日本法に準拠し、紛争は東京地方裁判所を第一審の専属的合意管轄裁判所とします。</p>
-<h3>16. 多言語版の優先言語</h3>
-<p>本規約の正文は日本語版です。他言語版との間に矛盾がある場合、日本語版を優先します。ただし、各居住国・地域の消費者保護法その他の強行法規に基づく利用者の権利を制限するものではありません。</p>
-<h3>17. 連絡先</h3>
-<p>合同会社AllNew お問い合わせ: <!--email_off-->app-support@allnew.work<!--/email_off--></p>
-<p>---</p>
-<p>運営: 合同会社AllNew</p>
-<p>© 2026 合同会社AllNew</p></section>
-    <section id="terms-en" data-lang="en"><h2>Terms of Service</h2><p>Last Updated: 2026-05-07</p>
-<p>These Terms of Service (&quot;Terms&quot;) govern your use of the iOS application &quot;80&#x27;s Camera&quot; (&quot;App&quot;) provided by AllNew LLC (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;).</p>
-<h3>1. Acceptance</h3>
-<p>By downloading, installing, or using the App, you agree to these Terms. If you do not agree, do not use the App.</p>
-<h3>2. Service Overview</h3>
-<p>The App provides software features as described in the App listing and in-app documentation. Feature availability may vary by device, region, account status, permissions, and platform policies.</p>
-<h3>3. Eligibility and Accounts</h3>
-<p>You must comply with applicable laws and platform requirements (including Apple account policies). If account features exist, you are responsible for account credentials and activity.</p>
-<h3>4. Free use and no billing</h3>
-<p>The App is offered for free and has no in-app purchases, subscriptions, or paid features. If paid features are added in the future, we will update the App Store listing, these Terms, and the legal page.</p>
-<h3>5. License and Permitted Use</h3>
-<p>We grant you a limited, non-exclusive, non-transferable, revocable license to use the App for personal or internal lawful purposes, subject to these Terms.</p>
-<h3>6. Prohibited Conduct</h3>
+<ul><li>本アプリの目的と異なる利用</li><li>法令または公序良俗に反する行為</li><li>第三者の権利、プライバシー、名誉、信用を侵害する行為</li><li>リバースエンジニアリング、解析、改変、複製、再配布</li><li>第三者のデータ、画像、音声、その他情報を無断で取得・記録・公開する行為</li><li>その他当社が不適切と判断する行為</li></ul>
+<h3>6. 重要情報に関する注意</h3>
+<p>本アプリは、ユーザーの日常的な記録、確認、整理、創作、または利便性向上を支援することを目的としたものであり、医療、法律、金融、その他専門的助言を提供するものではありません。専門的判断が必要な事項については、各分野の専門家にご相談ください。</p>
+<h3>7. 認識・処理精度について</h3>
+<p>本アプリが撮影、読み取り、変換、分類、加工、表示、同期、またはその他の自動処理を行う場合、その精度は100%ではありません。ユーザーは、処理結果を必要に応じて確認し、誤りがある場合は修正、削除、再実行等を行ってください。</p>
+<ul><li>認識精度や処理結果は、端末、OS、設定、権限、通信状態、入力品質、撮影条件、周囲環境等により変動します</li><li>本アプリの表示や処理結果は、最終判断の代替となるものではありません</li><li>誤った結果に基づく利用について、当社は法令で認められる範囲で責任を負いません</li></ul>
+<h3>8. 知的財産権</h3>
+<p>本アプリに関する著作権その他の知的財産権は、当社または正当な権利を有する第三者に帰属します。本規約により、ユーザーへ本アプリまたは関連資料に関する権利が移転するものではありません。</p>
+<h3>9. 免責事項</h3>
+<p>当社は、本アプリの機能が中断なく動作すること、認識結果、処理結果、表示内容、保存結果、同期結果等が常に正確であることを保証しません。</p>
+<p>当社は、ユーザーの端末、OS、Appleのサービス、ネットワーク、外部サービス、権限設定、またはユーザーの操作に起因する損害について責任を負いません。</p>
+<p>当社が損害賠償責任を負う場合でも、当社の故意または重過失がある場合を除き、当社の責任は通常かつ直接の損害に限られます。なお、消費者契約法その他の強行法規により制限される範囲では本項は適用されません。</p>
+<h3>10. 無料提供・課金なし</h3>
+<p>本アプリは無料で提供され、アプリ内課金、定期購読、有料機能はありません。</p>
+<h3>11. 規約の変更</h3>
+<p>当社は、必要に応じて本規約を変更することがあります。変更後の規約は、当社サイト、本アプリ内、またはその他合理的な方法で掲示された時点から効力を生じます。重要な変更については、合理的な方法により事前または事後に通知するよう努めます。</p>
+<h3>12. 準拠法・管轄</h3>
+<p>本規約は日本法に準拠します。本アプリまたは本規約に関して紛争が生じた場合、法令に別段の定めがある場合を除き、東京地方裁判所を第一審の専属的合意管轄裁判所とします。</p>
+<h3>13. 多言語版について</h3>
+<p>本利用規約は日本語を正文とします。他言語版との間に矛盾がある場合、日本語版を優先します。ただし、この規定は各居住国・地域の消費者保護法その他の強行法規に基づくユーザーの権利を制限するものではありません。</p></div></section>
+    <section id="terms-en" class="section" data-lang="en"><div class="section-header"><div class="section-icon">📜</div><div><div class="section-title">Terms of Service</div><div class="section-subtitle">Conditions for using the app</div></div></div><div class="legal-section"><p>Last Updated: 2026-05-07</p>
+<h3>1. Acceptance of Terms</h3>
+<p>These Terms of Service (&quot;Terms&quot;) govern your use of the iOS application &quot;80&#x27;s Camera&quot; (&quot;App&quot;) provided by AllNew LLC (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;). By using the App, you agree to these Terms.</p>
+<h3>2. Agreement to Terms</h3>
+<p>By downloading, installing, or using the App, you agree to be bound by these Terms. If you do not agree, do not use the App.</p>
+<h3>3. App Description and Compatibility</h3>
+<p>The App provides Pocket-sized retro film camera as described in the App Store listing and in-app documentation. The App uses the camera only for user-initiated capture and preview features. Captured images are processed on device and are not used for legal document generation or uploaded to AllNew servers.</p>
+<ul><li>Supported devices: iPhone running iOS 17.0 or later</li><li>Supported OS versions and available features may vary depending on device environment, region, permissions, and platform policies</li><li>The App assists content, records, review, organization, creation, or convenience based on user input, and we do not guarantee the accuracy or completeness of user-provided content</li></ul>
+<h3>4. Privacy Policy and Data Handling</h3>
+<p>Your use of the App is also governed by our Privacy Policy.</p>
+<p>For data you create, capture, save, or manage in the App, we commit to the following:</p>
+<ul><li>We do not use your data for advertising, marketing, or data mining purposes unless expressly described in the Privacy Policy</li><li>We do not sell or provide your data to data brokers or third parties</li><li>For features designed to work on device, we do not transmit or store your data on servers operated by us</li></ul>
+<h3>5. Prohibited Activities</h3>
 <p>You must not:</p>
-<ul><li>Violate laws or third-party rights</li><li>Reverse engineer, decompile, or attempt unauthorized access</li><li>Disrupt service operation, security, or integrity</li><li>Use the App for fraud, abuse, harassment, or harmful activities</li><li>Upload or transmit unlawful, infringing, or malicious content</li></ul>
-<h3>7. Intellectual Property</h3>
-<p>All intellectual property rights in the App and related materials belong to us or our licensors. These Terms do not transfer ownership rights.</p>
-<h3>8. Privacy</h3>
-<p>Information handling is described in our Privacy Policy. By using the App, you acknowledge that processing may occur as described there.</p>
-<h3>9. Availability, Changes, and Suspension</h3>
-<p>We may update, modify, limit, or discontinue part or all of the App at any time where legally permitted.</p>
-<h3>10. Disclaimer and Limitation of Liability</h3>
-<p>1. We do not guarantee that the App will meet your specific needs, that recognition errors will not occur, or that the App will be complete, accurate, or useful in all circumstances. 2. We are not liable for damages arising from specifications or issues related to your device, OS, or Apple services (Apple Health, iCloud, etc.). 3. Where we are liable, our liability shall be limited to ordinary and direct damages, except in cases of willful misconduct or gross negligence. This clause does not apply to the extent restricted by the Consumer Contract Act or other mandatory laws.</p>
-<h3>11. Indemnity</h3>
-<p>You agree to indemnify and hold us harmless from claims arising from your unlawful use of the App or your violation of these Terms.</p>
-<h3>12. Termination</h3>
-<p>We may suspend or terminate access if you materially violate these Terms, applicable law, or platform requirements.</p>
-<h3>13. Changes to Terms</h3>
-<p>We may amend these Terms as necessary. Amended Terms take effect upon posting on our website or other appropriate channels. For material changes, we will endeavor to provide advance notice through reasonable means.</p>
-<h3>14. Apple-Specific Terms</h3>
-<p>These Terms are between you and us, not Apple. Apple is not responsible for the App&#x27;s maintenance or support. Apple and its subsidiaries may be third-party beneficiaries of these Terms where applicable.</p>
-<h3>15. Governing Law and Jurisdiction</h3>
-<p>Unless mandatory local law provides otherwise, these Terms are governed by the laws of Japan, and disputes are subject to the exclusive jurisdiction of the Tokyo District Court as the court of first instance.</p>
-<h3>16. Translations</h3>
-<p>The Japanese version of these Terms is the authoritative text. If any translated version conflicts with the Japanese version, the Japanese version prevails. This does not limit rights granted to users under mandatory consumer-protection laws or other non-waivable regulations in their jurisdiction.</p>
-<h3>17. Contact</h3>
-<p>AllNew LLC Contact: <!--email_off-->app-support@allnew.work<!--/email_off--></p>
-<p>---</p>
-<p>Operator: AllNew LLC</p>
-<p>© 2026 AllNew LLC</p></section>
-    <section id="commercial-ja" data-lang="ja"><h2>特定商取引法に基づく表記</h2><table><tbody><tr><td>販売業者</td><td>合同会社AllNew</td></tr><tr><td>代表者</td><td>植野 正徳</td></tr><tr><td>所在地</td><td>〒107-0062 東京都港区南青山2-2-15 ウィン青山1419</td></tr><tr><td>連絡先</td><td><!--email_off-->app-support@allnew.work<!--/email_off--> / 電話番号は請求により開示します</td></tr><tr><td>価格</td><td>無料</td></tr><tr><td>支払方法</td><td>該当なし（アプリ内課金・定期購読なし）</td></tr><tr><td>提供時期</td><td>App Storeからダウンロード後、利用可能</td></tr><tr><td>返品・キャンセル</td><td>有料購入がないため該当しません。</td></tr></tbody></table></section>
-    <section id="commercial-en" data-lang="en"><h2>Commercial Transaction Disclosure</h2><table><tbody><tr><td>Seller</td><td>AllNew LLC</td></tr><tr><td>Representative</td><td>Masanori Ueno</td></tr><tr><td>Address</td><td>Win Aoyama 1419, 2-2-15 Minami-Aoyama, Minato-ku, Tokyo 107-0062, Japan</td></tr><tr><td>Contact</td><td><!--email_off-->app-support@allnew.work<!--/email_off-->; phone number disclosed upon request where required</td></tr><tr><td>Price</td><td>Free</td></tr><tr><td>Payment method</td><td>Not applicable; no in-app purchases or subscriptions</td></tr><tr><td>Delivery</td><td>Available after download from the App Store</td></tr><tr><td>Returns/Cancellations</td><td>Not applicable because there is no paid purchase.</td></tr></tbody></table></section>
-    <section id="contact-ja" data-lang="ja"><h2>お問い合わせ</h2><p><!--email_off--><a href="mailto:app-support@allnew.work">app-support@allnew.work</a><!--/email_off--></p><table><tbody><tr><td>メール</td><td><!--email_off-->app-support@allnew.work<!--/email_off--></td></tr><tr><td>受付時間</td><td>平日 11:00〜15:00（日本時間）</td></tr><tr><td>対応言語</td><td>日本語 / English</td></tr><tr><td>運営者</td><td>合同会社AllNew</td></tr><tr><td>所在地</td><td>〒107-0062 東京都港区南青山2-2-15 ウィン青山1419</td></tr></tbody></table></section>
-    <section id="contact-en" data-lang="en"><h2>Contact</h2><p><!--email_off--><a href="mailto:app-support@allnew.work">app-support@allnew.work</a><!--/email_off--></p><table><tbody><tr><td>Email</td><td><!--email_off-->app-support@allnew.work<!--/email_off--></td></tr><tr><td>Business hours</td><td>Mon-Fri 11:00-15:00 (JST)</td></tr><tr><td>Languages</td><td>Japanese / English</td></tr><tr><td>Operator</td><td>AllNew LLC</td></tr><tr><td>Address</td><td>Win Aoyama 1419, 2-2-15 Minami-Aoyama, Minato-ku, Tokyo 107-0062, Japan</td></tr></tbody></table></section>
+<ul><li>Use the App for purposes other than its intended purpose</li><li>Violate any laws or third-party rights</li><li>Infringe any third party&#x27;s privacy, reputation, credit, or intellectual property rights</li><li>Reverse engineer, decompile, modify, copy, or redistribute the App</li><li>Capture, record, publish, or otherwise use another person&#x27;s data, images, audio, or other information without permission</li><li>Engage in any other conduct we reasonably determine to be inappropriate</li></ul>
+<h3>6. Important Information Disclaimer</h3>
+<p>The App is intended to support everyday records, review, organization, creation, or convenience. It does not provide medical, legal, financial, or other professional advice. Please consult an appropriate professional for matters requiring expert judgment.</p>
+<h3>7. Recognition and Processing Accuracy</h3>
+<p>If the App performs capture, recognition, conversion, classification, editing, display, syncing, or other automated processing, accuracy is not 100%. You should review the results where necessary and correct, delete, or rerun processing if results are inaccurate.</p>
+<ul><li>Recognition accuracy and processing results may vary depending on device, OS, settings, permissions, network conditions, input quality, shooting conditions, and surrounding environment</li><li>App outputs and processing results are not a substitute for final human judgment</li><li>We are not liable for use based on inaccurate results to the extent permitted by law</li></ul>
+<h3>8. Intellectual Property</h3>
+<p>All intellectual property rights in the App and related materials belong to us or our licensors. These Terms do not transfer any rights in the App or related materials to you.</p>
+<h3>9. Disclaimer of Warranties</h3>
+<p>We do not guarantee that the App will operate without interruption, or that recognition results, processing results, displayed content, saved content, syncing, or any other App output will always be accurate.</p>
+<p>We are not liable for damages arising from your device, OS, Apple services, network, external services, permission settings, or your operation of the App.</p>
+<p>Where we are liable, our liability is limited to ordinary and direct damages, except in cases of willful misconduct or gross negligence. This clause does not apply to the extent restricted by the Consumer Contract Act or other mandatory laws.</p>
+<h3>10. Free use and no billing</h3>
+<p>The App is offered for free and has no in-app purchases, subscriptions, or paid features.</p>
+<h3>11. Changes to Terms</h3>
+<p>We may amend these Terms as necessary. Amended Terms take effect when posted on our website, in the App, or by other reasonable means. For material changes, we will endeavor to provide notice through reasonable means.</p>
+<h3>12. Governing Law and Jurisdiction</h3>
+<p>These Terms are governed by the laws of Japan. Unless mandatory local law provides otherwise, disputes related to the App or these Terms are subject to the exclusive jurisdiction of the Tokyo District Court as the court of first instance.</p>
+<h3>13. Translations</h3>
+<p>The Japanese version of these Terms is the authoritative text. If any translated version conflicts with the Japanese version, the Japanese version prevails. This does not limit rights granted to users under mandatory consumer-protection laws or other non-waivable regulations in their jurisdiction.</p></div></section>
+    <section id="commercial-ja" class="section" data-lang="ja"><div class="commercial-accordion"><button class="commercial-header" type="button" aria-expanded="false"><div class="section-header"><div class="section-icon">🏢</div><div><div class="section-title">特定商取引法に基づく表記</div><div class="section-subtitle">販売事業者情報</div></div></div><span class="commercial-toggle" aria-hidden="true">+</span></button><div class="commercial-content"><dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>代表者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0062 東京都港区南青山2-2-15 ウィン青山1419</dd></div><div class="contact-item"><dt>連絡先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--> / 電話番号は請求により開示します</dd></div><div class="contact-item"><dt>価格</dt><dd>無料</dd></div><div class="contact-item"><dt>支払方法</dt><dd>該当なし（アプリ内課金・定期購読なし）</dd></div><div class="contact-item"><dt>提供時期</dt><dd>App Storeからダウンロード後、利用可能</dd></div><div class="contact-item"><dt>返品・キャンセル</dt><dd>有料購入がないため該当しません。</dd></div></dl></div></div></section>
+    <section id="commercial-en" class="section" data-lang="en"><div class="commercial-accordion"><button class="commercial-header" type="button" aria-expanded="false"><div class="section-header"><div class="section-icon">🏢</div><div><div class="section-title">Seller Information</div><div class="section-subtitle">Specified Commercial Transactions Act (Japan)</div></div></div><span class="commercial-toggle" aria-hidden="true">+</span></button><div class="commercial-content"><dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>Seller</dt><dd>AllNew LLC</dd></div><div class="contact-item"><dt>Representative</dt><dd>Masanori Ueno</dd></div><div class="contact-item"><dt>Address</dt><dd>Win Aoyama 1419, 2-2-15 Minami-Aoyama, Minato-ku, Tokyo 107-0062, Japan</dd></div><div class="contact-item"><dt>Contact</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off-->; phone number disclosed upon request where required</dd></div><div class="contact-item"><dt>Price</dt><dd>Free</dd></div><div class="contact-item"><dt>Payment method</dt><dd>Not applicable; no in-app purchases or subscriptions</dd></div><div class="contact-item"><dt>Delivery</dt><dd>Available after download from the App Store</dd></div><div class="contact-item"><dt>Returns/Cancellations</dt><dd>Not applicable because there is no paid purchase.</dd></div></dl></div></div></section>
+    <section id="contact-ja" class="section" data-lang="ja"><div class="contact-card"><h2>お問い合わせ</h2><!--email_off--><a href="mailto:app-support@allnew.work?subject=80%27s%20Camera%20%3A%20" class="contact-email">✉️ メールを送る</a><!--/email_off--><dl class="contact-details contact-details-top" style="border-bottom: none;"><div class="contact-item"><dt>受付時間</dt><dd>平日 11:00〜15:00</dd></div><div class="contact-item"><dt>対応言語</dt><dd>日本語・英語</dd></div></dl></div></section>
+    <section id="contact-en" class="section" data-lang="en"><div class="contact-card"><h2>Contact Us</h2><!--email_off--><a href="mailto:app-support@allnew.work?subject=80%27s%20Camera%20%3A%20" class="contact-email">✉️ Send Email</a><!--/email_off--><dl class="contact-details contact-details-top" style="border-bottom: none;"><div class="contact-item"><dt>Hours</dt><dd>Weekdays 11:00-15:00 JST</dd></div><div class="contact-item"><dt>Languages</dt><dd>Japanese, English</dd></div></dl></div></section>
     <p class="muted">Hosted legal page: https://apps.allnew.work/pocketluma/</p>
   </main>
   <script>
@@ -258,9 +282,26 @@
       document.documentElement.lang = lang;
       try { localStorage.setItem('allnewLegalLang', lang); } catch (_) {}
     }
+    document.addEventListener('click', function(event) {
+      const header = event.target.closest('.commercial-header');
+      if (!header) return;
+      const accordion = header.closest('.commercial-accordion');
+      const isOpen = accordion.classList.toggle('open');
+      header.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    });
+    function checkCommercialAnchor() {
+      if (!location.hash || !location.hash.includes('commercial')) return;
+      document.querySelectorAll('.commercial-accordion').forEach(function(accordion) {
+        accordion.classList.add('open');
+        const header = accordion.querySelector('.commercial-header');
+        if (header) header.setAttribute('aria-expanded', 'true');
+      });
+    }
     const params = new URLSearchParams(location.search);
     const requested = params.get('lang') || (navigator.language || '').slice(0, 2);
     setLang(requested === 'ja' ? 'ja' : 'en');
+    checkCommercialAnchor();
+    window.addEventListener('hashchange', checkCommercialAnchor);
   </script>
 </body>
 </html>

--- a/pocketluma/index.html
+++ b/pocketluma/index.html
@@ -4,22 +4,7 @@
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>80&#x27;s Camera Support</title>
-  <meta name="description" content="80&#x27;s Camera is a pocket-sized retro compact camera inspired by the
-feel of 1980s keychain compacts. A cream plastic shell, a black
-lens-style preview window, a small LCD-style status strip, a
-physical-feeling shutter button, and a film-cartridge filter
-selector recreate that nostalgic point-and-shoot moment.
-
-Combine seven original filters (Classic C-400, Warm W-400,
-Flash F-200, Mono B&amp;W, Cool C-200, Toy Blue, Night Halation) with
-four playful frames (Rounded Compact, Date Stamp, Slide Border,
-Contact Sheet) to turn small everyday moments into warm,
-memorable photos.
-
-Everything happens on your iPhone. No accounts, no network calls,
-no analytics, no ads, no in-app purchases, no subscriptions. Your
-captures stay in the in-app gallery and only move to the Photos
-app when you tap Save.
+  <meta name="description" content="80&#x27;s Camera turns your iPhone into a tactile retro compact, with five film looks (Neutral, Warm, Cool, Sepia, B&amp;W), four frames (None, Classic, Polaroid, Film Strip), and an optional date stamp. Every photo is saved as the rendered final image — exactly what you see in the preview is what ends up in your gallery, the share sheet, and your Photos library. No account, no subscription, no ads, no analytics. Photos are processed entirely on your device and never leave it.
 ">
   <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:; script-src 'unsafe-inline'; form-action 'none'; base-uri 'self'">
   <meta name="referrer" content="no-referrer">
@@ -78,41 +63,12 @@ app when you tap Save.
   <main>
     <div class="hero" data-lang="ja">
       <h1>80&#x27;s Camera</h1>
-      <p class="lead">80&#x27;s Cameraは、1980年代の空気をまとったポケットサイズの
-レトロコンパクトカメラです。クリーム色のシェル、黒いレンズ窓、
-小さなLCD表示、物理シャッター風のボタン、フィルムカートリッジ風の
-フィルターセレクターで、なつかしい撮影体験を再現します。
-
-7種類のオリジナルフィルター（Classic C-400 / Warm W-400 /
-Flash F-200 / Mono B&amp;W / Cool C-200 / Toy Blue / Night Halation）と、
-4種類のフレーム（Rounded Compact / Date Stamp / Slide Border /
-Contact Sheet）を組み合わせて、日常の小さな瞬間を温かみのある
-一枚に変えられます。
-
-80&#x27;s Cameraはすべての処理を端末内で完結します。アカウント登録、
-ネットワーク通信、解析、広告、課金、サブスクリプションは一切ありません。
-撮影した写真はアプリ内ギャラリーに残り、必要なときだけあなたの
-操作で「写真」アプリへ保存できます。
+      <p class="lead">80年代のコンパクトカメラを思わせるタクタイルな操作感で、iPhoneを一台のフィルムカメラに変えるカメラアプリです。ニュートラル・ウォーム・クール・セピア・モノクロから選べる5種類のフィルムルック、4種類の枠（クラシック / ポラロイド / フィルム）、ON/OFFを切り替えられる日付スタンプを搭載。撮影した写真はすべてレンダリング後の最終画像として端末内に保存され、ギャラリー・共有・写真への保存にもそのまま使われます。アカウント登録、サブスクリプション、広告、外部送信は一切ありません。撮影は端末内で完結し、写真がインターネットに送られることはありません。
 </p>
     </div>
     <div class="hero" data-lang="en">
       <h1>80&#x27;s Camera</h1>
-      <p class="lead">80&#x27;s Camera is a pocket-sized retro compact camera inspired by the
-feel of 1980s keychain compacts. A cream plastic shell, a black
-lens-style preview window, a small LCD-style status strip, a
-physical-feeling shutter button, and a film-cartridge filter
-selector recreate that nostalgic point-and-shoot moment.
-
-Combine seven original filters (Classic C-400, Warm W-400,
-Flash F-200, Mono B&amp;W, Cool C-200, Toy Blue, Night Halation) with
-four playful frames (Rounded Compact, Date Stamp, Slide Border,
-Contact Sheet) to turn small everyday moments into warm,
-memorable photos.
-
-Everything happens on your iPhone. No accounts, no network calls,
-no analytics, no ads, no in-app purchases, no subscriptions. Your
-captures stay in the in-app gallery and only move to the Photos
-app when you tap Save.
+      <p class="lead">80&#x27;s Camera turns your iPhone into a tactile retro compact, with five film looks (Neutral, Warm, Cool, Sepia, B&amp;W), four frames (None, Classic, Polaroid, Film Strip), and an optional date stamp. Every photo is saved as the rendered final image — exactly what you see in the preview is what ends up in your gallery, the share sheet, and your Photos library. No account, no subscription, no ads, no analytics. Photos are processed entirely on your device and never leave it.
 </p>
     </div>
     <nav class="cards" data-lang="ja">
@@ -139,14 +95,14 @@ app when you tap Save.
 <h3>(A) ヘルスケア（Apple Health）データ</h3>
 <ul><li>本アプリは、ユーザーの許可に基づき、（該当なし）をヘルスケアへ行います。</li><li>本アプリは、ユーザーが任意に許可した場合に限り、ヘルスケア上のデータを読み取り、（該当なし）に利用します。</li><li>当社は、ヘルスケアデータを当社が運用する外部サーバーへ送信・保存しません。</li></ul>
 <h3>(B) カメラ画像（撮影画像）</h3>
-<ul><li>本アプリはカメラを使用しません。</li><li>当社は撮影画像を当社が運用する外部サーバーへ送信・保存しません。</li></ul>
+<ul><li>本アプリはカメラは、ユーザーが明示的に操作した撮影・プレビュー機能のためにのみ使用します。撮影画像は端末内で処理され、法務文書生成や外部サーバー送信には使用しません。</li><li>当社は撮影画像を当社が運用する外部サーバーへ送信・保存しません。</li></ul>
 <h3>(C) お問い合わせ情報（サポート）</h3>
 <ul><li>ユーザーがメール等で問い合わせを行う場合、メールアドレス、問い合わせ内容、ユーザーが任意で提供した情報（端末情報等）を受領します。</li></ul>
-<h3>(D) 購入に関する情報</h3>
-<ul><li>アプリ内課金に関する購入処理はAppleの仕組みにより行われます。当社はユーザーのクレジットカード情報等を取得しません。</li></ul>
+<h3>(D) 無料提供・支払情報</h3>
+<ul><li>本アプリは無料で提供され、アプリ内課金、定期購読、広告はありません。当社は購入情報、支払情報、クレジットカード情報を取得しません。</li></ul>
 <h3>2. 利用目的</h3>
 <p>当社は、上記情報を以下の目的で利用します。</p>
-<ul><li>本アプリの機能提供（ポケットのレトロカメラ）</li><li>サポート対応、問い合わせへの返信</li><li>不具合調査・品質改善（ユーザーが提供した範囲に限る）</li><li>法令遵守・紛争対応</li></ul>
+<ul><li>本アプリの機能提供（ポケットサイズのレトロカメラ）</li><li>サポート対応、問い合わせへの返信</li><li>不具合調査・品質改善（ユーザーが提供した範囲に限る）</li><li>法令遵守・紛争対応</li></ul>
 <h3>3. 第三者提供・外部送信</h3>
 <ul><li>当社は、（当社が収集する個人データはありません）、ヘルスケアから読み取ったデータ、および撮影画像を、当社が運用する外部サーバーへ送信・保存しません。</li><li>当社は、お問い合わせ情報等を、ユーザーの同意なく第三者へ提供しません。ただし、法令に基づく場合等を除きます。</li><li>ヘルスケアデータの保存・同期（iCloud等）やApple側処理の挙動は、ユーザーの端末設定およびAppleの仕様に従います。当社はAppleの挙動を制御できません。</li><li>当社は、（当社が収集する個人データはありません）を広告・マーケティング・プロファイリング目的で利用せず、第三者へ販売・貸与等もしません。</li><li>当社はiOSアプリ内に解析SDK（アナリティクスSDK）を導入していません。</li><li>本ウェブサイトでは、Vercel Web Analyticsを使用しています。Vercel Web AnalyticsはCookieを使用せず、個人を特定する情報を収集しません。ページビュー数、参照元、デバイスの種類などの集計データのみを収集します。</li></ul>
 <h3>4. 保管期間</h3>
@@ -178,14 +134,14 @@ app when you tap Save.
 <h3>(A) Apple Health data</h3>
 <ul><li>With your permission, the App performs (not applicable) to the Apple Health app (via HealthKit).</li><li>If you optionally grant read access, the App may use (not applicable).</li><li>We do not transmit or store Apple Health data on servers operated by us.</li></ul>
 <h3>(B) Camera images</h3>
-<ul><li>The App does not use the camera.</li><li>We do not transmit or store captured images on servers operated by us.</li></ul>
+<ul><li>The App uses the camera only for user-initiated capture and preview features. Captured images are processed on device and are not used for legal document generation or uploaded to AllNew servers..</li><li>We do not transmit or store captured images on servers operated by us.</li></ul>
 <h3>(C) Support communications</h3>
 <ul><li>If you email us, we may receive your email address, message content, and any information you include (e.g., device details), and use it to respond.</li></ul>
-<h3>(D) Purchases</h3>
-<ul><li>Payments are processed by Apple. We do not receive your card details.</li></ul>
+<h3>(D) Free use and payment information</h3>
+<ul><li>The App is offered for free and has no in-app purchases, subscriptions, or ads. We do not receive payment, purchase, or card information.</li></ul>
 <h3>2. Purposes</h3>
 <p>We use information only to:</p>
-<ul><li>Provide app functionality (A retro compact in your pocket)</li><li>Respond to support requests</li><li>Troubleshoot issues (based on what you provide)</li><li>Comply with law</li></ul>
+<ul><li>Provide app functionality (Pocket-sized retro film camera)</li><li>Respond to support requests</li><li>Troubleshoot issues (based on what you provide)</li><li>Comply with law</li></ul>
 <h3>3. Sharing &amp; Apple Services</h3>
 <ul><li>We do not use Apple Health data for advertising, marketing profiling, or data brokerage, and we do not sell such data.</li><li>We do not transmit or store your (we do not collect personal data), Apple Health read data, captured images, or motion data on servers operated by us.</li><li>Apple Health storage/sync (including iCloud) and Apple-side processing depend on your device settings and Apple&#x27;s system behavior. We do not control Apple&#x27;s behavior.</li><li>We do not use any analytics SDK in the iOS App.</li><li>This website uses Vercel Web Analytics. Vercel Web Analytics is cookie-free and does not collect personally identifiable information. It only collects aggregate data such as page views, referrers, and device types.</li></ul>
 <h3>4. Retention</h3>
@@ -218,8 +174,8 @@ app when you tap Save.
 <p>本アプリは、App Store記載内容およびアプリ内説明に基づく機能を提供します。機能の提供状況は、端末環境、地域、権限設定、プラットフォームポリシー等により異なる場合があります。</p>
 <h3>3. 利用資格・アカウント</h3>
 <p>ユーザーは、適用法令およびプラットフォーム規約を遵守して本アプリを利用するものとします。アカウント機能がある場合、認証情報の管理責任はユーザーにあります。</p>
-<h3>4. 課金・支払</h3>
-<p>1. 本アプリに課金機能がある場合、決済はAppleの仕組みを通じて処理されます。 2. 価格、請求、更新、解約、返金、税務の取扱いはApp Storeポリシーおよび適用法令に従います。 3. サブスクリプションがある場合、更新・解約はAppleアカウント設定で管理されます。</p>
+<h3>4. 無料提供・課金なし</h3>
+<p>本アプリは無料で提供され、アプリ内課金、定期購読、有料機能はありません。将来、有料機能を追加する場合は、App Store上の表示、本規約、および法務ページを更新します。</p>
 <h3>5. 利用許諾</h3>
 <p>当社は、ユーザーに対し、本規約に従うことを条件として、本アプリを適法な目的で利用するための限定的・非独占的・譲渡不能・取消可能な使用権を付与します。</p>
 <h3>6. 禁止事項</h3>
@@ -258,8 +214,8 @@ app when you tap Save.
 <p>The App provides software features as described in the App listing and in-app documentation. Feature availability may vary by device, region, account status, permissions, and platform policies.</p>
 <h3>3. Eligibility and Accounts</h3>
 <p>You must comply with applicable laws and platform requirements (including Apple account policies). If account features exist, you are responsible for account credentials and activity.</p>
-<h3>4. App Store, Purchases, and Billing</h3>
-<p>1. Purchases in the App are processed via Apple&#x27;s payment platform where applicable. 2. Prices, billing conditions, renewals, refunds, and taxes follow App Store policies and applicable law. 3. If the App offers subscriptions, renewal and cancellation are managed through your Apple account settings.</p>
+<h3>4. Free use and no billing</h3>
+<p>The App is offered for free and has no in-app purchases, subscriptions, or paid features. If paid features are added in the future, we will update the App Store listing, these Terms, and the legal page.</p>
 <h3>5. License and Permitted Use</h3>
 <p>We grant you a limited, non-exclusive, non-transferable, revocable license to use the App for personal or internal lawful purposes, subject to these Terms.</p>
 <h3>6. Prohibited Conduct</h3>
@@ -290,10 +246,10 @@ app when you tap Save.
 <p>---</p>
 <p>Operator: AllNew LLC</p>
 <p>© 2026 AllNew LLC</p></section>
-    <section id="commercial-ja" data-lang="ja"><h2>特定商取引法に基づく表記</h2><table><tbody><tr><td>販売業者</td><td>合同会社AllNew</td></tr><tr><td>代表者</td><td>植野 正徳</td></tr><tr><td>所在地</td><td>東京都</td></tr><tr><td>連絡先</td><td><!--email_off-->app-support@allnew.work<!--/email_off--> / 電話番号は請求により開示します</td></tr><tr><td>価格</td><td>App Store上に表示された価格（税込）</td></tr><tr><td>支払方法</td><td>Apple IDに登録された支払方法</td></tr><tr><td>提供時期</td><td>購入手続き完了後、即時利用可能</td></tr><tr><td>返品・キャンセル</td><td>デジタルコンテンツの性質上、購入後の返品はできません。Appleの返金ポリシーに従います。</td></tr></tbody></table></section>
-    <section id="commercial-en" data-lang="en"><h2>Commercial Transaction Disclosure</h2><table><tbody><tr><td>Seller</td><td>AllNew LLC</td></tr><tr><td>Representative</td><td>Masanori Ueno</td></tr><tr><td>Address</td><td>Tokyo, Japan</td></tr><tr><td>Contact</td><td><!--email_off-->app-support@allnew.work<!--/email_off-->; phone number disclosed upon request where required</td></tr><tr><td>Price</td><td>The price displayed on the App Store, including applicable tax</td></tr><tr><td>Payment method</td><td>Payment method registered with Apple ID</td></tr><tr><td>Delivery</td><td>Available immediately after purchase completion</td></tr><tr><td>Returns/Cancellations</td><td>Digital content is not returnable after purchase. Refunds follow Apple&#x27;s policy.</td></tr></tbody></table></section>
-    <section id="contact-ja" data-lang="ja"><h2>お問い合わせ</h2><p><!--email_off--><a href="mailto:app-support@allnew.work">app-support@allnew.work</a><!--/email_off--></p><table><tbody><tr><td>メール</td><td><!--email_off-->app-support@allnew.work<!--/email_off--></td></tr><tr><td>受付時間</td><td>平日 11:00〜15:00（日本時間）</td></tr><tr><td>対応言語</td><td>日本語 / English</td></tr><tr><td>運営者</td><td>合同会社AllNew</td></tr><tr><td>所在地</td><td>東京都</td></tr></tbody></table></section>
-    <section id="contact-en" data-lang="en"><h2>Contact</h2><p><!--email_off--><a href="mailto:app-support@allnew.work">app-support@allnew.work</a><!--/email_off--></p><table><tbody><tr><td>Email</td><td><!--email_off-->app-support@allnew.work<!--/email_off--></td></tr><tr><td>Business hours</td><td>Mon-Fri 11:00-15:00 (JST)</td></tr><tr><td>Languages</td><td>Japanese / English</td></tr><tr><td>Operator</td><td>AllNew LLC</td></tr><tr><td>Address</td><td>Tokyo, Japan</td></tr></tbody></table></section>
+    <section id="commercial-ja" data-lang="ja"><h2>特定商取引法に基づく表記</h2><table><tbody><tr><td>販売業者</td><td>合同会社AllNew</td></tr><tr><td>代表者</td><td>植野 正徳</td></tr><tr><td>所在地</td><td>〒107-0062 東京都港区南青山2-2-15 ウィン青山1419</td></tr><tr><td>連絡先</td><td><!--email_off-->app-support@allnew.work<!--/email_off--> / 電話番号は請求により開示します</td></tr><tr><td>価格</td><td>無料</td></tr><tr><td>支払方法</td><td>該当なし（アプリ内課金・定期購読なし）</td></tr><tr><td>提供時期</td><td>App Storeからダウンロード後、利用可能</td></tr><tr><td>返品・キャンセル</td><td>有料購入がないため該当しません。</td></tr></tbody></table></section>
+    <section id="commercial-en" data-lang="en"><h2>Commercial Transaction Disclosure</h2><table><tbody><tr><td>Seller</td><td>AllNew LLC</td></tr><tr><td>Representative</td><td>Masanori Ueno</td></tr><tr><td>Address</td><td>Win Aoyama 1419, 2-2-15 Minami-Aoyama, Minato-ku, Tokyo 107-0062, Japan</td></tr><tr><td>Contact</td><td><!--email_off-->app-support@allnew.work<!--/email_off-->; phone number disclosed upon request where required</td></tr><tr><td>Price</td><td>Free</td></tr><tr><td>Payment method</td><td>Not applicable; no in-app purchases or subscriptions</td></tr><tr><td>Delivery</td><td>Available after download from the App Store</td></tr><tr><td>Returns/Cancellations</td><td>Not applicable because there is no paid purchase.</td></tr></tbody></table></section>
+    <section id="contact-ja" data-lang="ja"><h2>お問い合わせ</h2><p><!--email_off--><a href="mailto:app-support@allnew.work">app-support@allnew.work</a><!--/email_off--></p><table><tbody><tr><td>メール</td><td><!--email_off-->app-support@allnew.work<!--/email_off--></td></tr><tr><td>受付時間</td><td>平日 11:00〜15:00（日本時間）</td></tr><tr><td>対応言語</td><td>日本語 / English</td></tr><tr><td>運営者</td><td>合同会社AllNew</td></tr><tr><td>所在地</td><td>〒107-0062 東京都港区南青山2-2-15 ウィン青山1419</td></tr></tbody></table></section>
+    <section id="contact-en" data-lang="en"><h2>Contact</h2><p><!--email_off--><a href="mailto:app-support@allnew.work">app-support@allnew.work</a><!--/email_off--></p><table><tbody><tr><td>Email</td><td><!--email_off-->app-support@allnew.work<!--/email_off--></td></tr><tr><td>Business hours</td><td>Mon-Fri 11:00-15:00 (JST)</td></tr><tr><td>Languages</td><td>Japanese / English</td></tr><tr><td>Operator</td><td>AllNew LLC</td></tr><tr><td>Address</td><td>Win Aoyama 1419, 2-2-15 Minami-Aoyama, Minato-ku, Tokyo 107-0062, Japan</td></tr></tbody></table></section>
     <p class="muted">Hosted legal page: https://apps.allnew.work/pocketluma/</p>
   </main>
   <script>


### PR DESCRIPTION
## Summary

- Refreshes only `pocketluma/index.html` from the v4.7-generated hosted legal page artifact.
- Removes stale paid/subscription wording from the current free 80's Camera / PocketLuma public legal page.
- Keeps shared support inbox `app-support@allnew.work` and required JA/EN anchors.

## Scope

- This is app-specific public HTML for PocketLuma.
- It does not change shared allnew-apps templates or other app pages.
- Existing untracked `debug/` remains untouched.

## Verification

- Confirmed `terms`, `privacy`, `commercial`, `contact`, and `faq` anchors are present.
- Confirmed shared support email is present.
- Confirmed stale paid-app phrases are absent:
  - `Purchases in the App are processed`
  - `If the App offers subscriptions`
  - `Apple IDに登録された支払方法`
