### PR TITLE
Align PocketLuma legal page with WeightSnap

### DIFF
--- a/pocketluma/index.html
+++ b/pocketluma/index.html
@@ -30,16 +30,27 @@
     * { box-sizing: border-box; }
     html { scroll-behavior: smooth; }
     body { margin: 0; font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Hiragino Sans", sans-serif; background: var(--bg); color: var(--text); line-height: 1.65; -webkit-font-smoothing: antialiased; }
-    header { position: sticky; top: 0; z-index: 10; background: var(--glass); backdrop-filter: blur(20px) saturate(180%); border-bottom: 1px solid var(--border); }
-    .nav { max-width: 860px; margin: 0 auto; padding: 12px 20px; display: flex; align-items: center; justify-content: space-between; gap: 16px; }
-    .brand { font-weight: 700; letter-spacing: .01em; }
-    .lang button { border: 1px solid var(--border); background: var(--panel); color: var(--text); border-radius: 999px; padding: 7px 12px; font-weight: 600; }
-    main { max-width: 860px; margin: 0 auto; padding: 42px 20px 80px; }
-    .hero { padding: 22px 0 30px; }
-    h1 { margin: 0 0 8px; font-size: clamp(2rem, 7vw, 4rem); line-height: 1; letter-spacing: -.03em; }
-    .lead { color: var(--muted); max-width: 680px; }
-    .cards { display: grid; grid-template-columns: repeat(auto-fit, minmax(145px, 1fr)); gap: 10px; margin: 26px 0 34px; }
-    .card { display: block; padding: 14px 16px; color: var(--text); text-decoration: none; background: var(--panel); border: 1px solid var(--border); border-radius: 14px; box-shadow: var(--shadow); font-weight: 650; }
+    .header { position: sticky; top: 0; z-index: 10; background: var(--glass); backdrop-filter: blur(20px) saturate(180%); border-bottom: 1px solid var(--border); }
+    .header-inner { max-width: 860px; margin: 0 auto; padding: 20px; display: flex; align-items: center; justify-content: space-between; gap: 16px; }
+    .logo-link { color: var(--text); text-decoration: none; display: inline-flex; align-items: center; gap: 12px; min-width: 0; }
+    .logo { font-weight: 800; letter-spacing: -.02em; font-size: 1.45rem; }
+    .logo-divider { width: 1px; height: 28px; background: var(--border); display: inline-block; }
+    .app-name { color: var(--muted); font-size: 1.2rem; font-weight: 650; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+    .lang-dropdown { position: relative; flex-shrink: 0; }
+    .lang-btn { border: 1px solid var(--border); background: var(--panel); color: var(--text); border-radius: 999px; padding: 10px 18px; font-weight: 700; box-shadow: var(--shadow); cursor: pointer; }
+    .lang-btn::after { content: "⌄"; margin-left: 7px; color: var(--muted); }
+    .lang-menu { display: none; position: absolute; right: 0; top: calc(100% + 8px); background: var(--panel); border: 1px solid var(--border); border-radius: 16px; box-shadow: var(--shadow); overflow: hidden; min-width: 150px; }
+    .lang-dropdown.open .lang-menu { display: block; }
+    .lang-option { display: block; width: 100%; border: 0; background: transparent; color: var(--text); padding: 11px 16px; text-align: left; font-weight: 650; cursor: pointer; }
+    .lang-option.active, .lang-option:hover { background: var(--bg-secondary); color: var(--accent); }
+    main, .main { max-width: 860px; margin: 0 auto; padding: 0 20px 80px; }
+    .hero { max-width: 860px; margin: 0 auto; padding: 66px 20px 46px; text-align: center; }
+    .hero-icon { width: 92px; height: 92px; border-radius: 24px; margin: 0 auto 24px; display: grid; place-items: center; background: linear-gradient(145deg, #f7e8c8, #f6c842); color: #1d1d1f; font-size: 42px; box-shadow: var(--shadow); }
+    h1 { margin: 0 0 14px; font-size: clamp(2.2rem, 7vw, 3.4rem); line-height: 1.05; letter-spacing: -.03em; }
+    .lead { color: var(--muted); max-width: 560px; margin: 0 auto; font-size: 1.15rem; line-height: 1.75; }
+    .toc { max-width: 760px; margin: 0 auto 52px; padding: 0 20px; display: flex; justify-content: center; align-items: center; gap: 22px; flex-wrap: wrap; }
+    .toc-link { color: var(--muted); text-decoration: none; font-size: 1.05rem; font-weight: 700; transition: color .2s ease; }
+    .toc-link:hover { color: var(--accent); }
     section { margin: 26px 0; padding: 24px; background: var(--panel); border: 1px solid var(--border); border-radius: var(--radius); box-shadow: var(--shadow); scroll-margin-top: 80px; }
     section h2 { margin: 0 0 14px; font-size: 1.45rem; letter-spacing: -.015em; }
     section h3 { margin: 22px 0 8px; font-size: 1.1rem; }
@@ -76,7 +87,12 @@
     body.lang-en [data-lang="ja"] { display: none; }
     body.lang-en [data-lang="en"] { display: block; }
     @media (max-width: 640px) {
-      main { padding: 30px 16px 70px; }
+      .header-inner { padding: 18px 16px; }
+      .logo { font-size: 1.2rem; }
+      .app-name { font-size: 1rem; max-width: 150px; }
+      main, .main { padding: 0 16px 70px; }
+      .hero { padding: 48px 16px 34px; }
+      .toc { gap: 18px; margin-bottom: 36px; }
       section { padding: 18px; }
       .section-header { flex-direction: column; text-align: center; }
       .commercial-header { padding: 18px; }
@@ -87,42 +103,51 @@
   </style>
 </head>
 <body>
-  <header>
-    <div class="nav">
-      <div><span class="brand">AllNew</span> <span class="muted">/ 80&#x27;s Camera</span></div>
-      <div class="lang">
-        <button type="button" onclick="setLang('ja')">日本語</button>
-        <button type="button" onclick="setLang('en')">English</button>
+  <header class="header">
+    <div class="header-inner">
+      <a href="https://apps.allnew.work/pocketluma/" class="logo-link" aria-label="AllNew 80&#x27;s Camera">
+        <span class="logo">AllNew</span>
+        <span class="logo-divider" aria-hidden="true"></span>
+        <span class="app-name">80&#x27;s Camera</span>
+      </a>
+      <div class="lang-dropdown" id="langDropdown">
+        <button class="lang-btn" type="button" onclick="toggleLangMenu()" aria-haspopup="true" aria-expanded="false"><span id="currentLang">日本語</span></button>
+        <div class="lang-menu" role="menu">
+          <button class="lang-option" type="button" data-lang-option="ja" onclick="setLang('ja')" role="menuitem">日本語</button>
+          <button class="lang-option" type="button" data-lang-option="en" onclick="setLang('en')" role="menuitem">English</button>
+        </div>
       </div>
     </div>
   </header>
-  <main>
-    <div class="hero" data-lang="ja">
+  <div class="hero" data-lang="ja">
+      <div class="hero-icon" aria-hidden="true">📷</div>
       <h1>80&#x27;s Camera</h1>
       <p class="lead">80年代のコンパクトカメラを思わせるタクタイルな操作感で、iPhoneを一台のフィルムカメラに変えるカメラアプリです。ニュートラル・ウォーム・クール・セピア・モノクロから選べる5種類のフィルムルック、4種類の枠（クラシック / ポラロイド / フィルム）、ON/OFFを切り替えられる日付スタンプを搭載。撮影した写真はすべてレンダリング後の最終画像として端末内に保存され、ギャラリー・共有・写真への保存にもそのまま使われます。アカウント登録、サブスクリプション、広告、外部送信は一切ありません。撮影は端末内で完結し、写真がインターネットに送られることはありません。
 </p>
-    </div>
-    <div class="hero" data-lang="en">
+  </div>
+  <div class="hero" data-lang="en">
+      <div class="hero-icon" aria-hidden="true">📷</div>
       <h1>80&#x27;s Camera</h1>
       <p class="lead">80&#x27;s Camera turns your iPhone into a tactile retro compact, with five film looks (Neutral, Warm, Cool, Sepia, B&amp;W), four frames (None, Classic, Polaroid, Film Strip), and an optional date stamp. Every photo is saved as the rendered final image — exactly what you see in the preview is what ends up in your gallery, the share sheet, and your Photos library. No account, no subscription, no ads, no analytics. Photos are processed entirely on your device and never leave it.
 </p>
-    </div>
-    <nav class="cards" data-lang="ja">
-<a class="card" href="#faq-ja">FAQ</a>
-<a class="card" href="#privacy-ja">プライバシー</a>
-<a class="card" href="#terms-ja">利用規約</a>
-<a class="card" href="#commercial-ja">特商法表記</a>
-<a class="card" href="#contact-ja">お問い合わせ</a>
+  </div>
+  <nav class="toc" data-lang="ja">
+<a class="toc-link" href="#faq-ja">FAQ</a>
+<a class="toc-link" href="#privacy-ja">プライバシー</a>
+<a class="toc-link" href="#terms-ja">利用規約</a>
+<a class="toc-link" href="#commercial-ja">特定商取引法</a>
+<a class="toc-link" href="#contact-ja">お問い合わせ</a>
 </nav>
-    <nav class="cards" data-lang="en">
-<a class="card" href="#faq-en">FAQ</a>
-<a class="card" href="#privacy-en">Privacy</a>
-<a class="card" href="#terms-en">Terms</a>
-<a class="card" href="#commercial-en">Commercial</a>
-<a class="card" href="#contact-en">Contact</a>
+  <nav class="toc" data-lang="en">
+<a class="toc-link" href="#faq-en">FAQ</a>
+<a class="toc-link" href="#privacy-en">Privacy</a>
+<a class="toc-link" href="#terms-en">Terms</a>
+<a class="toc-link" href="#commercial-en">Commercial</a>
+<a class="toc-link" href="#contact-en">Contact</a>
 </nav>
-    <section id="faq-ja" data-lang="ja"><h2>FAQ</h2><h3>このページで確認できる内容は？</h3><p>FAQ、プライバシーポリシー、利用規約、特定商取引法に基づく表記、お問い合わせ方法を確認できます。</p><h3>データはどこで処理されますか？</h3><p>ユーザーデータは原則として端末内で処理され、当社の外部サーバーへ送信・保存されません。</p><h3>問い合わせ先は？</h3><p>サポート窓口は <!--email_off-->app-support@allnew.work<!--/email_off--> です。</p></section>
-    <section id="faq-en" data-lang="en"><h2>FAQ</h2><h3>What can I find here?</h3><p>This page includes FAQ, Privacy Policy, Terms of Service, commercial disclosure, and contact details.</p><h3>Where is data processed?</h3><p>User data is processed on device by default and is not sent to or stored on AllNew servers.</p><h3>How can I contact support?</h3><p>Please contact <!--email_off-->app-support@allnew.work<!--/email_off-->.</p></section>
+  <main class="main">
+    <section id="faq-ja" class="section" data-lang="ja"><div class="section-header"><div class="section-icon">💡</div><div><div class="section-title">よくある質問</div><div class="section-subtitle">使い方や機能についてお答えします</div></div></div><div class="legal-section"><h3>このページで確認できる内容は？</h3><p>FAQ、プライバシーポリシー、利用規約、特定商取引法に基づく表記、お問い合わせ方法を確認できます。</p><h3>データはどこで処理されますか？</h3><p>ユーザーデータは原則として端末内で処理され、当社の外部サーバーへ送信・保存されません。</p><h3>問い合わせ先は？</h3><p>サポート窓口は <!--email_off-->app-support@allnew.work<!--/email_off--> です。</p></div></section>
+    <section id="faq-en" class="section" data-lang="en"><div class="section-header"><div class="section-icon">💡</div><div><div class="section-title">FAQ</div><div class="section-subtitle">Questions about using the app</div></div></div><div class="legal-section"><h3>What can I find here?</h3><p>This page includes FAQ, Privacy Policy, Terms of Service, commercial disclosure, and contact details.</p><h3>Where is data processed?</h3><p>User data is processed on device by default and is not sent to or stored on AllNew servers.</p><h3>How can I contact support?</h3><p>Please contact <!--email_off-->app-support@allnew.work<!--/email_off-->.</p></div></section>
     <section id="privacy-ja" class="section" data-lang="ja"><div class="section-header"><div class="section-icon">🔒</div><div><div class="section-title">プライバシーポリシー</div><div class="section-subtitle">データの取り扱い</div></div></div><div class="legal-section"><p>最終更新日: 2026-05-07</p>
 <p>**重要:** 本アプリは、ユーザーデータを当社の外部サーバーへ送信・保存しません。</p>
 <p>合同会社AllNew（以下「当社」）は、本アプリにおけるユーザー情報の取り扱いについて本ポリシーを定めます。当社の名称、住所、代表者等の事業者情報は、特定商取引法に基づく表示をご確認ください。</p>
@@ -270,19 +295,37 @@
 <p>These Terms are governed by the laws of Japan. Unless mandatory local law provides otherwise, disputes related to the App or these Terms are subject to the exclusive jurisdiction of the Tokyo District Court as the court of first instance.</p>
 <h3>13. Translations</h3>
 <p>The Japanese version of these Terms is the authoritative text. If any translated version conflicts with the Japanese version, the Japanese version prevails. This does not limit rights granted to users under mandatory consumer-protection laws or other non-waivable regulations in their jurisdiction.</p></div></section>
-    <section id="commercial-ja" class="section" data-lang="ja"><div class="commercial-accordion"><button class="commercial-header" type="button" aria-expanded="false"><div class="section-header"><div class="section-icon">🏢</div><div><div class="section-title">特定商取引法に基づく表記</div><div class="section-subtitle">販売事業者情報</div></div></div><span class="commercial-toggle" aria-hidden="true">+</span></button><div class="commercial-content"><dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>代表者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0062 東京都港区南青山2-2-15 ウィン青山1419</dd></div><div class="contact-item"><dt>連絡先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--> / 電話番号は請求により開示します</dd></div><div class="contact-item"><dt>価格</dt><dd>無料</dd></div><div class="contact-item"><dt>支払方法</dt><dd>該当なし（アプリ内課金・定期購読なし）</dd></div><div class="contact-item"><dt>提供時期</dt><dd>App Storeからダウンロード後、利用可能</dd></div><div class="contact-item"><dt>返品・キャンセル</dt><dd>有料購入がないため該当しません。</dd></div></dl></div></div></section>
-    <section id="commercial-en" class="section" data-lang="en"><div class="commercial-accordion"><button class="commercial-header" type="button" aria-expanded="false"><div class="section-header"><div class="section-icon">🏢</div><div><div class="section-title">Seller Information</div><div class="section-subtitle">Specified Commercial Transactions Act (Japan)</div></div></div><span class="commercial-toggle" aria-hidden="true">+</span></button><div class="commercial-content"><dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>Seller</dt><dd>AllNew LLC</dd></div><div class="contact-item"><dt>Representative</dt><dd>Masanori Ueno</dd></div><div class="contact-item"><dt>Address</dt><dd>Win Aoyama 1419, 2-2-15 Minami-Aoyama, Minato-ku, Tokyo 107-0062, Japan</dd></div><div class="contact-item"><dt>Contact</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off-->; phone number disclosed upon request where required</dd></div><div class="contact-item"><dt>Price</dt><dd>Free</dd></div><div class="contact-item"><dt>Payment method</dt><dd>Not applicable; no in-app purchases or subscriptions</dd></div><div class="contact-item"><dt>Delivery</dt><dd>Available after download from the App Store</dd></div><div class="contact-item"><dt>Returns/Cancellations</dt><dd>Not applicable because there is no paid purchase.</dd></div></dl></div></div></section>
+    <section id="commercial-ja" class="section" data-lang="ja"><div class="commercial-accordion"><button class="commercial-header" type="button" aria-expanded="false"><div class="section-header"><div class="section-icon">🏢</div><div><div class="section-title">特定商取引法に基づく表記</div><div class="section-subtitle">販売事業者情報</div></div></div><span class="commercial-toggle" aria-hidden="true">+</span></button><div class="commercial-content"><dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div><div class="contact-item"><dt>販売価格</dt><dd>無料</dd></div><div class="contact-item"><dt>代金の支払方法・時期</dt><dd>該当なし（アプリ内課金・定期購読なし）</dd></div><div class="contact-item"><dt>商品の引き渡し時期</dt><dd>App Storeからダウンロード後、すぐにご利用いただけます</dd></div><div class="contact-item"><dt>返品・キャンセルについて</dt><dd>有料購入がないため該当しません。</dd></div><div class="contact-item"><dt>特別条件</dt><dd>未成年者が利用する場合、親権者の同意を得た上でご利用ください</dd></div></dl></div></div></section>
+    <section id="commercial-en" class="section" data-lang="en"><div class="commercial-accordion"><button class="commercial-header" type="button" aria-expanded="false"><div class="section-header"><div class="section-icon">🏢</div><div><div class="section-title">Seller Information</div><div class="section-subtitle">Specified Commercial Transactions Act (Japan)</div></div></div><span class="commercial-toggle" aria-hidden="true">+</span></button><div class="commercial-content"><dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>Seller</dt><dd>AllNew LLC</dd></div><div class="contact-item"><dt>Representative</dt><dd>Masanori Ueno</dd></div><div class="contact-item"><dt>Address</dt><dd>Aoyama Tower Place 8F, 8-4-14 Akasaka, Minato-ku, Tokyo 107-0052, Japan</dd></div><div class="contact-item"><dt>Contact</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off-->; phone number disclosed upon request where required</dd></div><div class="contact-item"><dt>Price</dt><dd>Free</dd></div><div class="contact-item"><dt>Payment Method &amp; Timing</dt><dd>Not applicable; no in-app purchases or subscriptions</dd></div><div class="contact-item"><dt>Delivery</dt><dd>Available after download from the App Store</dd></div><div class="contact-item"><dt>Returns/Cancellations</dt><dd>Not applicable because there is no paid purchase.</dd></div><div class="contact-item"><dt>Special Conditions</dt><dd>Minors must use the App with consent from a parent or legal guardian.</dd></div></dl></div></div></section>
     <section id="contact-ja" class="section" data-lang="ja"><div class="contact-card"><h2>お問い合わせ</h2><!--email_off--><a href="mailto:app-support@allnew.work?subject=80%27s%20Camera%20%3A%20" class="contact-email">✉️ メールを送る</a><!--/email_off--><dl class="contact-details contact-details-top" style="border-bottom: none;"><div class="contact-item"><dt>受付時間</dt><dd>平日 11:00〜15:00</dd></div><div class="contact-item"><dt>対応言語</dt><dd>日本語・英語</dd></div></dl></div></section>
     <section id="contact-en" class="section" data-lang="en"><div class="contact-card"><h2>Contact Us</h2><!--email_off--><a href="mailto:app-support@allnew.work?subject=80%27s%20Camera%20%3A%20" class="contact-email">✉️ Send Email</a><!--/email_off--><dl class="contact-details contact-details-top" style="border-bottom: none;"><div class="contact-item"><dt>Hours</dt><dd>Weekdays 11:00-15:00 JST</dd></div><div class="contact-item"><dt>Languages</dt><dd>Japanese, English</dd></div></dl></div></section>
     <p class="muted">Hosted legal page: https://apps.allnew.work/pocketluma/</p>
   </main>
   <script>
+    function toggleLangMenu() {
+      const dropdown = document.getElementById('langDropdown');
+      dropdown.classList.toggle('open');
+      const button = dropdown.querySelector('.lang-btn');
+      button.setAttribute('aria-expanded', dropdown.classList.contains('open') ? 'true' : 'false');
+    }
     function setLang(lang) {
       document.body.classList.toggle('lang-en', lang === 'en');
       document.documentElement.lang = lang;
+      document.getElementById('currentLang').textContent = lang === 'ja' ? '日本語' : 'English';
+      document.querySelectorAll('.lang-option').forEach(function(option) {
+        option.classList.toggle('active', option.dataset.langOption === lang);
+      });
+      const dropdown = document.getElementById('langDropdown');
+      dropdown.classList.remove('open');
+      dropdown.querySelector('.lang-btn').setAttribute('aria-expanded', 'false');
       try { localStorage.setItem('allnewLegalLang', lang); } catch (_) {}
     }
     document.addEventListener('click', function(event) {
+      const dropdown = document.getElementById('langDropdown');
+      if (dropdown && !dropdown.contains(event.target)) {
+        dropdown.classList.remove('open');
+        dropdown.querySelector('.lang-btn').setAttribute('aria-expanded', 'false');
+      }
       const header = event.target.closest('.commercial-header');
       if (!header) return;
       const accordion = header.closest('.commercial-accordion');


### PR DESCRIPTION
## Summary
- sync the regenerated v4.7 PocketLuma legal page to allnew-apps
- correct the AllNew address to Aoyama Tower Place 8F
- align the commercial disclosure/contact/header/toc structure with WeightSnap while preserving free-app wording

## Verification
- rg confirmed the canonical Akasaka address and WeightSnap-style labels are present
- untracked debug/ was left untouched