### PR TITLE
fix(babyvox): escape apostrophe in en subtitle (commercial accordion broken)

### DIFF
--- a/babyvox/index.html
+++ b/babyvox/index.html
@@ -1349,7 +1349,7 @@
         // Language Data
         const langData = {
             ja: { label: '日本語', hero: 'BabyVox', subtitleLine1: '声で記録。タップ不要。', subtitleLine2: 'シンプルな乳幼児の成長記録。', toc: ['FAQ', 'プライバシー', '利用規約', '特定商取引法', 'お問い合わせ'] },
-            en: { label: 'English', hero: 'BabyVox', subtitle: 'Just Say It. No more Tap.<br>The Simplest Way to Track Your Baby's Growth.', toc: ['FAQ', 'Privacy', 'Terms', 'Seller Info', 'Contact'] }
+            en: { label: 'English', hero: 'BabyVox', subtitle: "Just Say It. No more Tap.<br>The Simplest Way to Track Your Baby's Growth.", toc: ['FAQ', 'Privacy', 'Terms', 'Seller Info', 'Contact'] }
         };
 
         // Get current language from URL hash or default to ja


### PR DESCRIPTION
## Summary

BabyVox `apps.allnew.work/babyvox/?lang=ja` の `langData.en.subtitle` 内に未エスケープのアポストロフィー (`Baby's`) があり、シングルクォートの文字列リテラルを途中で閉じてしまっていました。結果、`<script>` ブロック全体が JavaScript 構文エラーで実行されず、以下が機能不全：

- 特定商取引法アコーディオンの "+" ボタン
- FAQ アコーディオン
- 言語切替（`switchLanguage`）
- `checkCommercialAnchor()`（ディープリンクからの自動展開）

ユーザーが App Store からインストールした BabyVox 実機（iPhone Safari）で「特商法のページで + ボタンをタップしても開かない」と報告して発覚。

## Fix

`subtitle` の外側クォートを `'` から `"` に変更し、アポストロフィーを自然に含められるようにしました。

## Verification

- 修正前: `node -e "eval('var x = ' + langData)"` → SyntaxError
- 修正後: `node -e "eval('var x = ' + langData)"` → OK
- 同じパターンが他の 9 AllNew アプリの `index.html` にないことを確認済み（全件パース OK）

## Test plan

- [ ] Cloudflare Pages デプロイ後、`apps.allnew.work/babyvox/?lang=ja#commercial-ja` を実機で開き、+ ボタンが反応することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)