### PR TITLE
Update MedReminder legal docs for subscription pricing

### DIFF
--- a/medreminder/index.html
+++ b/medreminder/index.html
@@ -753,9 +753,11 @@
                 </div>
 
                 <div class="faq-item">
-                    <div class="faq-question">無料で使えますか？<span class="faq-icon">+</span></div>
+                    <div class="faq-question">料金はいくらですか？<span class="faq-icon">+</span></div>
                     <div class="faq-answer">
-                        <p><strong>完全無料</strong>でお使いいただけます。広告・アプリ内課金・サブスクリプション・トラッキングは一切ありません。</p>
+                        <p>初回起動時から<strong>1 ヶ月間は無料</strong>でお試しいただけます。体験期間中はすべての機能を制限なくお使いいただけます。</p>
+                        <p>1 ヶ月の体験期間終了後は <strong>年額 500 円（税込）</strong>のサブスクリプションが自動的に開始されます。広告・トラッキングは一切ありません。</p>
+                        <p>解約は <strong>iPhone の「設定」→ Apple ID →「サブスクリプション」</strong>からいつでも可能です。解約しても次回の課金日まではすべての機能を引き続きご利用いただけます。</p>
                     </div>
                 </div>
 
@@ -842,7 +844,8 @@
                         <li><strong>家族プロフィール情報:</strong> ユーザーが任意で登録した家族メンバーの名前と表示用シンボル・カラータグ。お使いの iPhone のみに保存されます。</li>
                         <li><strong>服薬記録 (HealthKit):</strong> 「ヘルスケアに記録」を有効にした場合のみ、服用時刻を Apple HealthKit の「マインドフルネス時間」カテゴリへ書き込みます（iOS に服薬専用カテゴリがないため代替として使用）。HealthKit の保存・同期挙動はユーザーの端末設定および Apple の仕様に従います。</li>
                         <li><strong>iCloud Key-Value Storage:</strong> 「iCloud 同期」を有効にした場合のみ、お薬一覧・プロフィール・最近の服薬記録の小さなスナップショットを、ユーザー自身の Apple ID 配下の iCloud KV 領域にミラーリングします。Apple ID は当社では取得・保管しません。</li>
-                        <li><strong>収集しない情報:</strong> 本アプリでは広告 SDK・アナリティクスサービスを使用せず、ユーザー登録機能・課金機能はありません。位置情報・連絡先・カレンダー・SNS 連携は使用しません。</li>
+                        <li><strong>収集しない情報:</strong> 本アプリでは広告 SDK・アナリティクスサービスを使用せず、ユーザー登録機能はありません。位置情報・連絡先・カレンダー・SNS 連携は使用しません。</li>
+                        <li><strong>サブスクリプション情報:</strong> 「MedReminder Pro」サブスクリプション (1 ヶ月無料体験後 年額 500 円) のお支払い情報は <strong>Apple ID 経由で Apple が処理</strong> し、当社は決済情報・クレジットカード番号・購読者氏名等を一切受け取りません。当社が知るのは、Apple の StoreKit から返される購読の有効/無効状態（端末上で検証）のみです。</li>
                     </ul>
                 </div>
 
@@ -1034,8 +1037,16 @@
                 </div>
 
                 <div class="legal-section">
-                    <h3>11. 料金</h3>
-                    <p>本アプリは<strong>完全無料</strong>でご利用いただけます。広告・アプリ内課金・サブスクリプションはありません。</p>
+                    <h3>11. 料金・サブスクリプション</h3>
+                    <p>本アプリは<strong>1 ヶ月の無料体験</strong>のあと、<strong>年額 500 円（税込）</strong>の自動更新サブスクリプション「MedReminder Pro」へ移行します。</p>
+                    <ul>
+                        <li><strong>無料体験:</strong> 初回購読時から 1 ヶ月間、すべての機能を制限なくお試しいただけます。体験期間中に課金は発生しません。</li>
+                        <li><strong>定期課金:</strong> 体験期間終了の 24 時間前までに自動更新を解除しない場合、Apple ID に登録されている支払い方法に年額 500 円（税込）が課金され、以降毎年同額が自動更新されます。</li>
+                        <li><strong>解約方法:</strong> iPhone の「設定」 → ご自身の Apple ID →「サブスクリプション」 → 「MedReminder Pro」から、いつでも自動更新を解除できます。解約は次回課金日以降に反映されます。</li>
+                        <li><strong>返金:</strong> Apple の購入規約に従い Apple サポートを通じてのみ返金請求を受け付けます。当社では決済情報を保持しないため、当社経由での返金処理はできません。</li>
+                        <li><strong>価格変更:</strong> 当社が価格を改定する場合、改定前に App Store および本アプリ内で通知します。変更を希望されない場合は次回更新前にサブスクリプションを解除してください。</li>
+                        <li><strong>体験期間後の機能:</strong> 体験期間後にサブスクリプションを開始しない場合、本アプリの追加・編集機能は利用できなくなります。ただし安全のため、体験期間中に登録済みのリマインダー通知は引き続き発火します。</li>
+                    </ul>
                 </div>
 
                 <div class="legal-section">
@@ -1073,10 +1084,14 @@
                             <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
                             <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
                             <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>無料（アプリ内課金・サブスクリプションはありません）</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>該当なし（本アプリは完全無料です）</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>App Store からダウンロード後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>該当なし（本アプリは完全無料のため返金事項はありません）</dd></div>
+                            <div class="contact-item"><dt>販売価格</dt><dd>MedReminder Pro（年額自動更新サブスクリプション） 500 円（税込）／年<br><small>※ App Store の表示価格が正規価格となります（為替・税率改定により変動する場合があります）</small></dd></div>
+                            <div class="contact-item"><dt>無料体験</dt><dd>初回購読時から 1 ヶ月間（30 日間）。体験期間中の課金はありません。体験期間終了の 24 時間前までに解除しない場合、自動的に有料サブスクリプションへ移行します</dd></div>
+                            <div class="contact-item"><dt>商品代金以外の必要料金</dt><dd>本アプリのご利用にあたって発生する通信料・データ通信費はお客様のご負担となります</dd></div>
+                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>Apple ID に登録された支払い方法（クレジットカード／キャリア決済／App Store ギフトカード等）で、無料体験期間終了時に初回課金が行われます。以降は毎年同日に自動更新課金が行われます</dd></div>
+                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>App Store からのダウンロード直後にすべての機能をご利用いただけます</dd></div>
+                            <div class="contact-item"><dt>解約方法</dt><dd>iPhone の「設定」 → Apple ID →「サブスクリプション」 → 「MedReminder Pro」 →「サブスクリプションをキャンセル」からいつでも解約できます。解約は次回課金日以降に反映され、それまでは引き続きご利用いただけます</dd></div>
+                            <div class="contact-item"><dt>返金・キャンセルについて</dt><dd>Apple の購入規約に基づき、Apple サポートを通じてのみ返金請求を受け付けます（reportaproblem.apple.com）。当社では決済情報を保持しないため、当社経由での返金処理は行えません</dd></div>
+                            <div class="contact-item"><dt>動作環境</dt><dd>iOS 26.0 以降を搭載した iPhone。Apple Intelligence 自動抽出機能には Apple Intelligence 対応端末（A17 Pro / A18 / M シリーズ搭載 iPhone）が必要です</dd></div>
                             <div class="contact-item"><dt>特別条件</dt><dd>本アプリは医療機器ではなく、リマインダーツールです。医療的判断は医師・薬剤師にご相談ください</dd></div>
                         </dl>
                     </div>
@@ -1144,9 +1159,11 @@
                 </div>
 
                 <div class="faq-item">
-                    <div class="faq-question">Is it free?<span class="faq-icon">+</span></div>
+                    <div class="faq-question">How much does it cost?<span class="faq-icon">+</span></div>
                     <div class="faq-answer">
-                        <p><strong>Completely free.</strong> No ads, no in-app purchases, no subscriptions, no tracking.</p>
+                        <p><strong>Free for the first month.</strong> Every feature is unlocked during the 1-month trial with no charge.</p>
+                        <p>After the trial, MedReminder converts to a <strong>¥500 / year (tax included) auto-renewing subscription</strong>. No ads or tracking, ever.</p>
+                        <p>Cancel anytime via your iPhone's <strong>Settings → Apple ID → Subscriptions</strong>. Cancellation takes effect at the next renewal date; you keep full access until then.</p>
                     </div>
                 </div>
 
@@ -1233,7 +1250,8 @@
                         <li><strong>Family profiles:</strong> Names, display symbols, color tags for family members you optionally register. Stored on this iPhone only.</li>
                         <li><strong>Intake records (HealthKit):</strong> If "Record to Health" is enabled, intake times are written as Apple HealthKit "Mindful Minutes" samples (used as a substitute because iOS has no medication-specific category). HealthKit storage/sync behavior follows your device settings and Apple's specifications.</li>
                         <li><strong>iCloud Key-Value Storage:</strong> If "iCloud Sync" is enabled, a compact snapshot of medications, profiles, and recent intake history is mirrored to your own Apple ID's iCloud KV space. We do not collect or store your Apple ID.</li>
-                        <li><strong>Not collected:</strong> The app contains no ad SDKs, no analytics services, no user accounts, no in-app purchases. Location, contacts, calendar, and social-media integration are not used.</li>
+                        <li><strong>Not collected:</strong> The app contains no ad SDKs, no analytics services, no user accounts. Location, contacts, calendar, and social-media integration are not used.</li>
+                        <li><strong>Subscription data:</strong> The "MedReminder Pro" subscription (¥500 / year after the 1-month free trial) is processed entirely through your Apple ID. <strong>Apple handles all payment information</strong> — we never receive payment details, card numbers, or subscriber names. The only signal we receive (verified on-device via StoreKit) is whether your subscription is active.</li>
                     </ul>
                 </div>
 
@@ -1425,8 +1443,16 @@
                 </div>
 
                 <div class="legal-section">
-                    <h3>11. Fees</h3>
-                    <p>The App is <strong>completely free</strong>. No ads, no in-app purchases, no subscriptions.</p>
+                    <h3>11. Fees and subscription</h3>
+                    <p>The App is offered on a <strong>1-month free trial</strong> basis, after which it converts to the <strong>MedReminder Pro</strong> auto-renewing subscription at <strong>¥500 (tax included) per year</strong>.</p>
+                    <ul>
+                        <li><strong>Free trial:</strong> Every feature is unlocked at no charge for the first month after subscription start. No payment is taken during the trial.</li>
+                        <li><strong>Auto-renewal:</strong> Unless cancelled at least 24 hours before the trial ends, your Apple ID payment method is charged ¥500 (tax included) and the subscription renews annually thereafter at the same price.</li>
+                        <li><strong>Cancellation:</strong> Cancel anytime via Settings → Apple ID → Subscriptions → MedReminder Pro on your iPhone. Cancellation takes effect at the next renewal date; access continues until then.</li>
+                        <li><strong>Refunds:</strong> Per Apple's Media Services terms, refund requests are handled by Apple via reportaproblem.apple.com. We do not retain payment information and cannot issue refunds directly.</li>
+                        <li><strong>Price changes:</strong> If we change the price, we'll notify you on the App Store and in the App before the new price applies. You may cancel before the next renewal if you don't accept the change.</li>
+                        <li><strong>After the trial:</strong> If you choose not to subscribe, you can no longer add or edit medications. For safety, reminder notifications already scheduled during the trial continue to fire.</li>
+                    </ul>
                 </div>
 
                 <div class="legal-section">
@@ -1464,10 +1490,14 @@
                             <div class="contact-item"><dt>Operations Lead</dt><dd>Masanori Ueno</dd></div>
                             <div class="contact-item"><dt>Address</dt><dd>Aoyama Tower Place 8F, 8-4-14 Akasaka, Minato-ku, Tokyo 107-0052, Japan</dd></div>
                             <div class="contact-item"><dt>Contact</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※Phone number disclosed upon written request.</small></dd></div>
-                            <div class="contact-item"><dt>Price</dt><dd>Free (no in-app purchases or subscriptions)</dd></div>
-                            <div class="contact-item"><dt>Payment method / timing</dt><dd>Not applicable (the app is completely free)</dd></div>
-                            <div class="contact-item"><dt>Delivery</dt><dd>Available immediately after installing from the App Store</dd></div>
-                            <div class="contact-item"><dt>Returns / cancellations</dt><dd>Not applicable (the app is completely free; no refund cases arise)</dd></div>
+                            <div class="contact-item"><dt>Price</dt><dd>MedReminder Pro (annual auto-renewing subscription) — ¥500 (tax included) / year<br><small>※ The App Store displays the authoritative price (may vary by currency / tax changes)</small></dd></div>
+                            <div class="contact-item"><dt>Free trial</dt><dd>1 month (30 days) from the start of the first subscription. No charge during the trial. Conversion to the paid subscription is automatic unless cancelled at least 24 hours before the trial ends</dd></div>
+                            <div class="contact-item"><dt>Additional fees</dt><dd>Mobile data charges for using the App are at your own cost</dd></div>
+                            <div class="contact-item"><dt>Payment method / timing</dt><dd>Charged to the payment method registered with your Apple ID (credit card / carrier billing / App Store gift card, etc.) when the trial ends; auto-renews annually on the same date</dd></div>
+                            <div class="contact-item"><dt>Delivery</dt><dd>Every feature is available immediately after installing from the App Store</dd></div>
+                            <div class="contact-item"><dt>Cancellation</dt><dd>Cancel anytime via your iPhone's Settings → Apple ID → Subscriptions → MedReminder Pro → Cancel Subscription. Cancellation takes effect at the next renewal date; access continues until then</dd></div>
+                            <div class="contact-item"><dt>Refunds / cancellations</dt><dd>Refund requests are handled by Apple Support per Apple's terms (reportaproblem.apple.com). We do not retain payment data and cannot process refunds directly</dd></div>
+                            <div class="contact-item"><dt>Requirements</dt><dd>iPhone running iOS 26.0 or later. Apple Intelligence auto-fill requires an Apple-Intelligence-capable device (A17 Pro / A18 / M-series iPhone)</dd></div>
                             <div class="contact-item"><dt>Special conditions</dt><dd>The App is a reminder tool, not a medical device. Medical decisions must be consulted with a physician or pharmacist</dd></div>
                         </dl>
                     </div>


### PR DESCRIPTION
## Summary
- Convert MedReminder web legal docs from "completely free" to a 1-month free trial + ¥500/year auto-renewing subscription (MedReminder Pro)
- FAQ, Terms §11, Commercial Law Notice, and Privacy Policy "Not collected" all updated in JA + EN
- Adds full Apple §3.1.2(a) disclosure (trial length, price, auto-renew terms, cancellation method) and 特商法 itemized pricing/payment/cancellation/refund block
- Privacy: clarifies that payment data is handled by Apple and never reaches the developer

## Test plan
- [ ] Cloudflare Pages picks up the change and deploys
- [ ] Open `https://apps.allnew.work/medreminder/?lang=ja#commercial-ja` — confirm price line shows `年額 500 円 (税込)`
- [ ] Open `https://apps.allnew.work/medreminder/?lang=ja#terms-ja` — §11 mentions 1 ヶ月 + 500 円 + 解約方法
- [ ] Open `https://apps.allnew.work/medreminder/?lang=ja#faq-ja` — pricing FAQ visible
- [ ] Open `https://apps.allnew.work/medreminder/?lang=ja#privacy-ja` — subscription data section mentions Apple-handled payment
- [ ] Repeat all of the above for `?lang=en#*-en`
- [ ] In the app, the in-app Safari sheet from Settings → 法務 still anchors correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)