### PR TITLE
feat(seo/security): block AI training crawlers + attack probes

### DIFF
--- a/_redirects
+++ b/_redirects
@@ -1,0 +1,34 @@
+# _redirects — Cloudflare Pages
+#
+# Return 404 for known attack paths and recursive SPA bait so crawlers
+# stop chasing them. Without this, every unknown path falls through to
+# the SPA root and returns 200, which causes:
+#   - GPTBot to chase /landing-automation/runtime/* recursively
+#   - Probing scripts (WP/PHP/git) to think the site is alive
+#
+# Cloudflare Pages syntax: `<source> <status>` returns that status
+# directly. `<source> <destination> <status>` rewrites first.
+
+# WordPress / PHP probes (we are pure static, no PHP)
+/wp-login.php 404
+/wp-admin/* 404
+/wp-includes/* 404
+/wp-config.php 404
+/xmlrpc.php 404
+/*.php 404
+
+# Dotfile / VCS / config probes
+/.env 404
+/.env.* 404
+/.git/* 404
+/.svn/* 404
+/.aws/* 404
+/.ssh/* 404
+/config.json 404
+/credentials.json 404
+
+# Hide internal/runtime paths from crawlers (also Disallowed in robots.txt)
+/landing-automation/* 404
+/debug/* 404
+/test-results/* 404
+/.planning/* 404

--- a/_redirects
+++ b/_redirects
@@ -27,7 +27,11 @@
 /config.json 404
 /credentials.json 404
 
-# Hide internal/runtime paths from crawlers (also Disallowed in robots.txt)
+# Hide internal/runtime paths from crawlers (also Disallowed in robots.txt).
+# IMPORTANT: index.html references `landing-automation/runtime/landing-runtime.js`
+# — that exact path must still serve 200. Allowlist it BEFORE the wildcard block
+# (first-match-wins).
+/landing-automation/runtime/landing-runtime.js /landing-automation/runtime/landing-runtime.js 200
 /landing-automation/* 404
 /debug/* 404
 /test-results/* 404

--- a/robots.txt
+++ b/robots.txt
@@ -1,38 +1,130 @@
 # robots.txt — apps.allnew.work
-# Allow all crawlers including AI bots
+#
+# LLM/AI bot strategy:
+#
+# - SEARCH/CITATION bots (drive traffic via AI answer engines): ALLOW.
+#   These crawl on-demand and link back to our site from AI responses.
+# - TRAINING bots (collect content to train models): BLOCK.
+#   Content gets ingested into model weights with no attribution or
+#   referral traffic.
+# - SEO scrapers (Ahrefs/Semrush/MJ12 etc.): BLOCK. High request volume,
+#   no business benefit.
+#
+# Background: Cloudflare Zone Analytics showed GPTBot was hammering
+# this site at ~164,000 req/24h (99.5% of total traffic) chasing
+# /landing-automation/ recursive SPA paths.
+#
+# References:
+#   https://platform.openai.com/docs/bots
+#   https://docs.anthropic.com/en/docs/agents-and-tools/web-fetch-tool
+#   https://docs.perplexity.ai/guides/bots
 
+# --- Default: allow with rate hint ---
 User-agent: *
 Allow: /
+Disallow: /landing-automation/
+Disallow: /debug/
+Disallow: /test-results/
+Disallow: /.planning/
+Disallow: /assets/raw/
+Crawl-delay: 10
 
-# AI Crawlers — explicitly welcomed
-User-agent: GPTBot
-Allow: /
-
-User-agent: ChatGPT-User
-Allow: /
-
-User-agent: ClaudeBot
-Allow: /
-
-User-agent: Claude-Web
-Allow: /
-
-User-agent: PerplexityBot
-Allow: /
-
-User-agent: Applebot
-Allow: /
-
+# --- Major search engines: allow ---
 User-agent: Googlebot
 Allow: /
+Disallow: /landing-automation/
 
 User-agent: Bingbot
 Allow: /
+Disallow: /landing-automation/
 
-User-agent: cohere-ai
+User-agent: Applebot
 Allow: /
+Disallow: /landing-automation/
+
+# --- AI search/citation bots: ALLOW (link us in AI answers) ---
+User-agent: OAI-SearchBot
+Allow: /
+Disallow: /landing-automation/
+
+User-agent: ChatGPT-User
+Allow: /
+Disallow: /landing-automation/
+
+User-agent: PerplexityBot
+Allow: /
+Disallow: /landing-automation/
+
+User-agent: Perplexity-User
+Allow: /
+Disallow: /landing-automation/
+
+User-agent: Claude-SearchBot
+Allow: /
+Disallow: /landing-automation/
+
+User-agent: Claude-User
+Allow: /
+Disallow: /landing-automation/
+
+# --- AI training bots: BLOCK ---
+User-agent: GPTBot
+Disallow: /
+
+User-agent: CCBot
+Disallow: /
+
+User-agent: ClaudeBot
+Disallow: /
+
+User-agent: Claude-Web
+Disallow: /
+
+User-agent: anthropic-ai
+Disallow: /
 
 User-agent: Google-Extended
-Allow: /
+Disallow: /
+
+User-agent: Bytespider
+Disallow: /
+
+User-agent: Meta-ExternalAgent
+Disallow: /
+
+User-agent: Meta-ExternalFetcher
+Disallow: /
+
+User-agent: Applebot-Extended
+Disallow: /
+
+User-agent: Diffbot
+Disallow: /
+
+User-agent: Omgilibot
+Disallow: /
+
+User-agent: FacebookBot
+Disallow: /
+
+User-agent: cohere-ai
+Disallow: /
+
+User-agent: ImagesiftBot
+Disallow: /
+
+# --- High-volume SEO scrapers: BLOCK ---
+User-agent: MJ12bot
+Disallow: /
+
+User-agent: AhrefsBot
+Disallow: /
+
+User-agent: SemrushBot
+Disallow: /
+
+User-agent: DotBot
+Disallow: /
 
 Sitemap: https://apps.allnew.work/sitemap.xml
+Host: https://apps.allnew.work


### PR DESCRIPTION
## Summary

apps.allnew.work が OpenAI GPTBot に大量クロールされている (約164,000 req/24h, 全ゾーントラフィックの 99.5%) のを止めつつ、検索系AIへの参照は維持。

## 背景

Cloudflare Zone Analytics (過去24h) で判明:

- **GPTBot から 164,524 req/24h** が apps.allnew.work に集中
- 内容: `/bpsnap/ja/bloodpressuresnap/pupweight/landing-automation/runtime/coughwav/...` のような長い再帰パス
- 根本原因2層:
  1. **現状の robots.txt が GPTBot を `Allow: /` で歓迎**
  2. **CF Pagesが SPA fallback で全unknown path → index.html(200) を返す** + index.html の `<script src=\"landing-automation/runtime/...\">` 等が **相対パス** のため、bot は `/foo/bar/landing-automation/runtime/...` を新たなURLと誤認して延々と巡回

## 変更内容

### robots.txt 全面改訂

| カテゴリ | 旧 | 新 |
|---------|----|----|
| GPTBot / CCBot / ClaudeBot / Bytespider 等 (学習用) | ✅ Allow | ❌ Disallow |
| OAI-SearchBot / ChatGPT-User / PerplexityBot / Claude-SearchBot (検索/参照) | (未指定) | ✅ Allow |
| Googlebot / Bingbot / Applebot | ✅ Allow | ✅ Allow (`/landing-automation/` だけ Disallow) |
| MJ12bot / AhrefsBot / SemrushBot | (未指定) | ❌ Disallow |
| 全クローラー | (未指定) | `Crawl-delay: 10`, `/landing-automation/` `/debug/` `/test-results/` Disallow |

### `_redirects` 新規追加

CF Pages の `_redirects` で攻撃プローブを即 404 化:

```
/wp-login.php 404
/wp-admin/* 404
/.env 404
/.env.* 404
/.git/* 404
/*.php 404
/landing-automation/* 404
/debug/* 404
/test-results/* 404
```

これで `/wp-login.php` 等の WordPress プローブが index.html (200) ではなく 404 を返すようになります。

## Test plan

- [ ] CI green
- [ ] Preview deployで以下を確認:
  - `/robots.txt` に新ポリシー反映
  - `/wp-login.php`, `/.env`, `/xmlrpc.php`, `/foo.php` → 404
  - `/landing-automation/runtime/landing-runtime.js` も `_redirects` の `/landing-automation/*` にマッチして404になる可能性。index.htmlがこのスクリプトを参照しているため、もし壊れたら `_redirects` から除外。
  - 通常ページ (`/`, `/weightsnap/`, `/bloodpressuresnap/`) は 200
- [ ] マージ後、1〜2日でCFアナリティクスでGPTBotリクエスト数の減少を確認

## ⚠️ 既知の未解決問題 (フォローアップ推奨)

`_redirects` の `/landing-automation/*` が **index.htmlの script タグも 404 化する可能性**:

```html
<script src="landing-automation/runtime/landing-runtime.js"></script>
```

実機で確認し、もし `landing-runtime.js` がロードされなくなったら:
- A) `_redirects` の該当行を削除 → robots.txtだけで対処
- B) index.htmlの script を別パスに移動 (例: `/runtime/landing-runtime.js`) → 再帰パス問題も同時解決
- C) `/landing-automation/runtime/landing-runtime.js 200` ルールを `/landing-automation/* 404` より上に追加 (allowlist 方式)

理想は **B (index.html を絶対パス + ルート直下に移動)** ですが、別PRで対応するのが安全。

## SPA fallback の根本対策 (このPRの範囲外)

CF Pages の "Single Page Application" モード設定が dashboard で有効化されている可能性が高く、これが再帰パス問題の根本原因です。本PRはトラフィック削減の応急処置で、根本対策は別途:
- CF Pages dashboard で SPA mode を無効化、または
- index.html の相対パスを絶対パス (`/landing-automation/...`) に書き換え

🤖 Generated with [Claude Code](https://claude.com/claude-code)