### PR TITLE
Update Tokusho disclosures for live app pages

### DIFF
--- a/babyvox/index.html
+++ b/babyvox/index.html
@@ -1019,17 +1019,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/bloodpressuresnap/index.html
+++ b/bloodpressuresnap/index.html
@@ -1020,17 +1020,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/botto/index.html
+++ b/botto/index.html
@@ -983,17 +983,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/coughwav/index.html
+++ b/coughwav/index.html
@@ -1016,17 +1016,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/glucosnap/index.html
+++ b/glucosnap/index.html
@@ -1020,17 +1020,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/medreminder/index.html
+++ b/medreminder/index.html
@@ -994,13 +994,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div>
-                            <div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/oxisnap/index.html
+++ b/oxisnap/index.html
@@ -1018,17 +1018,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/pawpass/index.html
+++ b/pawpass/index.html
@@ -994,13 +994,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div>
-                            <div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/pupweight/index.html
+++ b/pupweight/index.html
@@ -1016,17 +1016,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/thermometersnap/index.html
+++ b/thermometersnap/index.html
@@ -1003,17 +1003,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/thermosnap/index.html
+++ b/thermosnap/index.html
@@ -1020,17 +1020,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/waistvox/index.html
+++ b/waistvox/index.html
@@ -1015,17 +1015,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>

--- a/weightsnap/index.html
+++ b/weightsnap/index.html
@@ -1037,17 +1037,7 @@
                         <span class="commercial-toggle">+</span>
                     </div>
                     <div class="commercial-content">
-                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;">
-                            <div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div>
-                            <div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div>
-                            <div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div>
-                            <div class="contact-item"><dt>お問い合わせ先</dt><dd><!--email_off-->app-support@allnew.work<!--/email_off--><br><small>※電話番号は請求があれば遅滞なく開示します</small></dd></div>
-                            <div class="contact-item"><dt>販売価格</dt><dd>アプリ内の購入画面に記載された価格</dd></div>
-                            <div class="contact-item"><dt>代金の支払方法・時期</dt><dd>App Storeが提供する決済手段によります。購入確定時にAppleから課金されます</dd></div>
-                            <div class="contact-item"><dt>商品の引き渡し時期</dt><dd>購入手続き完了後、すぐにご利用いただけます</dd></div>
-                            <div class="contact-item"><dt>返品・キャンセルについて</dt><dd>アプリの特性上、購入確定後の返品・キャンセルはお受けできません。返金の可否・手続はAppleの返金ポリシーに従います。</dd></div>
-                            <div class="contact-item"><dt>特別条件</dt><dd>未成年者が購入する場合、親権者の同意を得た上でご利用ください</dd></div>
-                        </dl>
+                        <dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl>
                     </div>
                 </div>
             </section>


### PR DESCRIPTION
Replaces the Japanese specified commercial transactions disclosure rows on live AllNew app support pages with the MedReminder best-practice wording. Scope is limited to the app support pages touched by this branch.