### PR TITLE
fix(feedback): make Cookie settings reachable for anonymous visitors

### DIFF
--- a/feedback/app.js
+++ b/feedback/app.js
@@ -346,6 +346,7 @@ document.addEventListener("DOMContentLoaded", () => {
   const cookieConsentAccept = document.getElementById("cookieConsentAccept");
   const cookieConsentEssential = document.getElementById("cookieConsentEssential");
   const cookieSettingsLink = document.getElementById("cookieSettingsLink");
+  const signinCookieSettingsLink = document.getElementById("signinCookieSettingsLink");
   const isLocalPreviewHost = ["localhost", "127.0.0.1", ""].includes(window.location.hostname);
   let termsModalRequiresRegistrationConsent = false;
   let termsModalConsentChecklistRequired = false;
@@ -829,10 +830,12 @@ document.addEventListener("DOMContentLoaded", () => {
       setCookieConsentDecision(false);
       setCookieBannerVisible(false);
     });
-    cookieSettingsLink?.addEventListener("click", () => {
+    const reopenConsentBanner = () => {
       setCookieBannerVisible(true);
       cookieConsentBanner.scrollIntoView({ behavior: "smooth", block: "end" });
-    });
+    };
+    cookieSettingsLink?.addEventListener("click", reopenConsentBanner);
+    signinCookieSettingsLink?.addEventListener("click", reopenConsentBanner);
   }
 
   function setScrollyStep(stage, stepIndex) {

--- a/feedback/index.html
+++ b/feedback/index.html
@@ -3796,8 +3796,11 @@
       cursor: progress;
     }
 
+    /* Always visible (incl. anonymous visitors) so the consent banner's
+       "ページ下部のCookie設定でいつでも変更できます" promise holds and
+       consent withdrawal stays as easy as giving it. */
     .portal-legal-footer {
-      display: none;
+      display: block;
       width: min(100%, 640px);
       margin: 48px auto 0;
       padding: 18px 10px 0;
@@ -3806,10 +3809,6 @@
       font-weight: 650;
       line-height: 1.7;
       text-align: center;
-    }
-
-    .is-authenticated .portal-legal-footer {
-      display: block;
     }
 
     .is-chat-active .portal-legal-footer {
@@ -3828,6 +3827,7 @@
 
     .portal-legal-links a,
     .signin-legal-links a,
+    .signin-legal-links .portal-legal-link-button,
     .policy-link {
       color: var(--blue);
       text-decoration: none;
@@ -3836,6 +3836,7 @@
 
     .portal-legal-links a:hover,
     .signin-legal-links a:hover,
+    .signin-legal-links .portal-legal-link-button:hover,
     .policy-link:hover {
       text-decoration: underline;
     }
@@ -4912,6 +4913,7 @@
                   <li><a href="./terms.html">利用規約</a></li>
                   <li><a href="https://www.allnew.work/ja/privacy">プライバシーポリシー</a></li>
                   <li><a href="./cookie-policy.html">Cookie/外部送信ポリシー</a></li>
+                  <li><button type="button" class="portal-legal-link-button" id="signinCookieSettingsLink">Cookie設定</button></li>
                 </ul>
               </div>
             </section>
@@ -5506,6 +5508,6 @@
 
   <script src="./i18n.js?v=20260611-legal-en" defer></script>
   <script src="https://appleid.cdn-apple.com/appleauth/static/jsapi/appleid/1/ja_JP/appleid.auth.js" defer></script>
-  <script src="./app.js?v=20260611-legal-en" defer></script>
+  <script src="./app.js?v=20260611-cookie-settings" defer></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- The `Cookie設定` (consent re-open) link existed only in the portal legal footer, which is CSS-gated to `.is-authenticated`. Anonymous visitors are intentionally scroll-clamped at the sign-in scene, so after making a consent choice they had **no UI to change it** — although the banner text promises 「選択は後からページ下部の「Cookie設定」でいつでも変更できます」.
- Add a `Cookie設定` button to the sign-in scene's existing legal links row (`signin-legal-links`) — the one place anonymous visitors always reach.
- Make the portal legal footer visible for everyone (benefits guest mode); pre-auth landing visuals are unchanged because the scroll clamp keeps it below the viewport.
- Both links share one `reopenConsentBanner` handler. app.js cache buster bumped to `20260611-cookie-settings`.

## Verification (local Playwright against this branch)
- Anonymous JA: banner appears at sign-in scene → 「必須のみ許可」 → click new `Cookie設定` in scene → banner reopens ✅
- EN (`?lang=en`): button auto-translates to "Cookie settings" (i18n TreeWalker string match) ✅
- Link matches sibling legal links visually (blue, hover underline); console errors: 0 ✅
- `node --check feedback/app.js` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)