### PR TITLE
Show merged feedback voices on POIPOI board

### DIFF
--- a/feedback/app.js
+++ b/feedback/app.js
@@ -645,6 +645,7 @@ document.addEventListener("DOMContentLoaded", () => {
       title: payload.title || payload.body?.slice(0, 48) || "受付内容",
       body: payload.body || "",
       publicStatus: report.publicStatus || "受け付けました",
+      similarRequest: report.similarRequest || null,
       acceptedAt: receivedAt,
       updatedAt: report.updatedAt || receivedAt,
       nickname: currentNickname || generateNickname()
@@ -1461,6 +1462,12 @@ document.addEventListener("DOMContentLoaded", () => {
     });
 
     message.append(intro, title, rows);
+    if (report.similarRequest?.message) {
+      const similar = document.createElement("p");
+      similar.className = "chat-receipt-similar";
+      similar.textContent = report.similarRequest.message;
+      message.append(similar);
+    }
     feedbackChatLog.append(message);
     feedbackChatLog.scrollTop = feedbackChatLog.scrollHeight;
     return message;
@@ -1965,7 +1972,10 @@ document.addEventListener("DOMContentLoaded", () => {
     if (!response.ok || result.ok !== true) {
       throw new Error(result.error || `feedback_submit_${response.status}`);
     }
-    return result.item;
+    return {
+      ...(result.item || {}),
+      similarRequest: result.similarRequest || result.item?.similarRequest || null
+    };
   }
 
   function getUserFacingSubmitError(error) {
@@ -2161,6 +2171,7 @@ document.addEventListener("DOMContentLoaded", () => {
       publicStatus: persistedItem?.publicStatus || review.publicStatus,
       adminState: persistedItem?.adminState || "needs_review",
       factoryJobId: persistedItem?.factoryJobId || null,
+      similarRequest: persistedItem?.similarRequest || null,
       suggestedNextStatus: review.decision === "accept" ? "検討しています" : "ごめんなさい",
       flags,
       adminSummary: review.adminSummary,

--- a/feedback/index.html
+++ b/feedback/index.html
@@ -2821,6 +2821,18 @@
       overflow-wrap: anywhere;
     }
 
+    .chat-receipt-similar {
+      margin: 0;
+      padding: 11px 12px;
+      border: 1px solid rgba(10, 125, 255, 0.16);
+      border-radius: 16px;
+      color: var(--blue-deep);
+      background: color-mix(in srgb, var(--brand-blue-bright) 7%, #ffffff);
+      font-size: 13px;
+      font-weight: 760;
+      line-height: 1.6;
+    }
+
     .chat-post-reception-actions {
       display: flex;
       flex-wrap: wrap;

--- a/feedback/status-board.css
+++ b/feedback/status-board.css
@@ -673,6 +673,77 @@ body.is-empty-public-board .board-grid {
   line-height: 1.45;
 }
 
+.request-similar {
+  display: grid;
+  gap: 8px;
+  margin: 0;
+  padding: 11px 12px;
+  border: 1px solid color-mix(in srgb, var(--blue) 14%, transparent);
+  border-radius: 14px;
+  background: color-mix(in srgb, var(--blue) 5%, #fff);
+}
+
+.request-similar-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 7px;
+  color: var(--blue-deep);
+}
+
+.request-similar-head strong {
+  font-size: 12px;
+  font-weight: 720;
+}
+
+.request-similar-head span {
+  color: color-mix(in srgb, var(--muted) 82%, transparent);
+  font-size: 11px;
+  font-weight: 560;
+}
+
+.request-similar ul {
+  display: grid;
+  gap: 7px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.request-similar li {
+  display: grid;
+  grid-template-columns: 72px minmax(70px, auto) 1fr;
+  gap: 7px;
+  align-items: start;
+  min-width: 0;
+  color: color-mix(in srgb, var(--ink) 76%, transparent);
+  font-size: 11px;
+  font-weight: 500;
+  line-height: 1.45;
+}
+
+.request-similar time {
+  color: color-mix(in srgb, var(--muted) 86%, transparent);
+  font-variant-numeric: tabular-nums;
+  white-space: nowrap;
+}
+
+.request-similar li > strong {
+  color: var(--blue-deep);
+  font-size: 11px;
+  font-weight: 690;
+}
+
+.request-similar li > span {
+  min-width: 0;
+  overflow-wrap: anywhere;
+}
+
+.request-similar-more {
+  grid-template-columns: 1fr !important;
+  color: color-mix(in srgb, var(--muted) 88%, transparent);
+}
+
 .request-timeline {
   display: grid;
   gap: 8px;
@@ -1283,6 +1354,16 @@ body.is-empty-public-board .board-grid {
   .request-timing,
   .request-detail {
     font-size: 12.5px;
+  }
+
+  .request-similar li {
+    grid-template-columns: 1fr;
+    gap: 2px;
+  }
+
+  .request-similar time,
+  .request-similar li > strong {
+    white-space: normal;
   }
 
   .timeline-row {

--- a/feedback/status-board.js
+++ b/feedback/status-board.js
@@ -24,12 +24,33 @@ const PUBLIC_STATUS_TIMELINE_NOTES = {
   "ごめんなさい": "今回は見送りとなりました"
 };
 
+function formatBoardDate(value) {
+  const date = String(value || "").slice(0, 10);
+  return date ? date.replaceAll("-", "/") : "日付未記録";
+}
+
+function normalizeSimilarRequests(entry) {
+  const requests = Array.isArray(entry.similarRequests) ? entry.similarRequests : [];
+  return requests
+    .map((request) => ({
+      id: request.id || "",
+      title: request.title || "",
+      submitterName: request.submitterName || "匿名ユーザー",
+      submittedAt: request.submittedAt || "",
+      publicStatus: request.publicStatus || entry.publicStatus || "受け付けました"
+    }))
+    .filter((request) => request.id || request.title || request.submittedAt)
+    .slice(0, 8);
+}
+
 function mapPublicApiItem(entry) {
   const isVirtual = Boolean(entry.app?.isVirtual);
   const appName = entry.app?.name || (isVirtual ? "New App Idea" : "アプリ");
   const accepted = String(entry.createdAt || "").slice(0, 10);
   const updated = String(entry.updatedAt || entry.createdAt || "").slice(0, 10) || accepted;
   const status = entry.publicStatus || "受け付けました";
+  const similarRequests = normalizeSimilarRequests(entry);
+  const similarRequestCount = Math.max(Number(entry.similarRequestCount) || 0, similarRequests.length || 1);
   const timeline = [[accepted.replaceAll("-", "/"), "ご要望を受け付けました"]];
   if (status !== "受け付けました" && updated && updated !== accepted) {
     timeline.push([updated.replaceAll("-", "/"), PUBLIC_STATUS_TIMELINE_NOTES[status] || status]);
@@ -49,6 +70,8 @@ function mapPublicApiItem(entry) {
     detail: entry.summary || "",
     good: Number(entry.goodCount) || 0,
     owned: false,
+    similarRequestCount,
+    similarRequests,
     timeline
   };
 }
@@ -201,7 +224,10 @@ function itemMatches(item) {
   const categoryMatch = filters.category === "all" || item.category === filters.category;
   const appMatch = filters.app === "all" || item.app === filters.app;
   const query = filters.query.trim().toLowerCase();
-  const queryMatch = !query || `${item.id} ${item.app} ${item.appDisplayName || ""} ${item.category} ${item.title} ${item.detail}`.toLowerCase().includes(query);
+  const similarText = (item.similarRequests || [])
+    .map((request) => `${request.id} ${request.title} ${request.submitterName}`)
+    .join(" ");
+  const queryMatch = !query || `${item.id} ${item.app} ${item.appDisplayName || ""} ${item.category} ${item.title} ${item.detail} ${similarText}`.toLowerCase().includes(query);
   return statusMatch && categoryMatch && appMatch && queryMatch;
 }
 
@@ -264,6 +290,47 @@ function createTimeline(item, compact = false) {
   return timeline;
 }
 
+function createSimilarRequestsBlock(item, { compact = true } = {}) {
+  if (item.owned || Number(item.similarRequestCount || 0) <= 1) return null;
+  const requests = Array.isArray(item.similarRequests) ? item.similarRequests : [];
+  if (!requests.length) return null;
+
+  const block = document.createElement("div");
+  block.className = "request-similar";
+
+  const head = document.createElement("div");
+  head.className = "request-similar-head";
+  const label = document.createElement("strong");
+  label.textContent = `同じ声 ${item.similarRequestCount}件`;
+  const caption = document.createElement("span");
+  caption.textContent = "受付履歴";
+  head.append(label, caption);
+
+  const list = document.createElement("ul");
+  const visibleRequests = compact ? requests.slice(0, 3) : requests;
+  visibleRequests.forEach((request) => {
+    const row = document.createElement("li");
+    const when = document.createElement("time");
+    when.textContent = formatBoardDate(request.submittedAt);
+    const who = document.createElement("strong");
+    who.textContent = request.submitterName || "匿名ユーザー";
+    const title = document.createElement("span");
+    title.textContent = `${request.id ? `${request.id} / ` : ""}${request.title || item.title}`;
+    row.append(when, who, title);
+    list.append(row);
+  });
+
+  if (compact && requests.length > visibleRequests.length) {
+    const more = document.createElement("li");
+    more.className = "request-similar-more";
+    more.textContent = `ほか ${requests.length - visibleRequests.length}件は「詳しく見る」で確認できます。`;
+    list.append(more);
+  }
+
+  block.append(head, list);
+  return block;
+}
+
 function createCard(item) {
   const card = document.createElement("article");
   card.className = `request-card${item.owned ? " is-owned" : ""}`;
@@ -299,6 +366,7 @@ function createCard(item) {
   const detail = document.createElement("p");
   detail.className = "request-detail";
   detail.textContent = item.detail;
+  const similarBlock = createSimilarRequestsBlock(item, { compact: true });
   const compactStatus = document.createElement("p");
   compactStatus.className = "request-latest";
   const latest = item.timeline[item.timeline.length - 1];
@@ -327,7 +395,9 @@ function createCard(item) {
   if (!item.owned) actions.append(good);
   actions.append(detailButton);
 
-  card.append(top, title, timing, detail, compactStatus, actions);
+  card.append(top, title, timing, detail);
+  if (similarBlock) card.append(similarBlock);
+  card.append(compactStatus, actions);
   return card;
 }
 
@@ -353,10 +423,13 @@ function openDetail(item) {
   const detail = document.createElement("p");
   detail.className = "request-detail";
   detail.textContent = item.detail;
+  const similarBlock = createSimilarRequestsBlock(item, { compact: false });
   const timelineTitle = document.createElement("h3");
   timelineTitle.className = "detail-section-title";
   timelineTitle.textContent = "これまでの流れ";
-  detailBody.append(close, meta, status, title, detail, timelineTitle, createTimeline(item, false));
+  detailBody.append(close, meta, status, title, detail);
+  if (similarBlock) detailBody.append(similarBlock);
+  detailBody.append(timelineTitle, createTimeline(item, false));
   detailDialog.showModal();
 }
 


### PR DESCRIPTION
## Summary
- render similar-request history on the POIPOI status board as 同じ声 with submitter/date/request details
- surface BaaS similar-request messages in the post-submit receipt from Poina
- style the merged-voices block with AllNew blue tokens and responsive layout

## Verification
- node --check feedback/status-board.js && node --check feedback/app.js
- Playwright DOM sample via local status-board fixture: 1 card, 同じ声 3件, overflows 0