### PR TITLE
Add FormFitInvoice hosted legal page

### DIFF
--- a/formfitinvoice/index.html
+++ b/formfitinvoice/index.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="ja">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>見積・請求書作成 サポート</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Yu Gothic", sans-serif; margin: 0; color: #172033; background: #f7fafc; }
+    main { max-width: 880px; margin: 0 auto; padding: 32px 20px 56px; }
+    header { padding: 28px 0 18px; }
+    h1 { font-size: 2rem; margin: 0 0 8px; }
+    h2 { font-size: 1.25rem; margin: 28px 0 10px; }
+    section { background: #fff; border: 1px solid #d8e0ea; border-radius: 8px; padding: 18px; margin: 16px 0; }
+    a { color: #0f6b8f; }
+    dl { display: grid; grid-template-columns: minmax(130px, 180px) 1fr; gap: 8px 16px; }
+    dt { font-weight: 700; }
+    dd { margin: 0; }
+  </style>
+</head>
+<body>
+<main>
+  <header>
+    <h1>見積・請求書作成</h1>
+    <p>FormFit Invoice support and privacy information.</p>
+  </header>
+  <section id="faq-ja">
+    <h2>サポート / Support</h2>
+    <p>見積・請求書作成 は、フリーランスや小規模事業者が端末内で見積書・請求書を作成し、PDFとして共有するためのアプリです。</p>
+    <p>お問い合わせは <a href="mailto:app-support@allnew.work">app-support@allnew.work</a> までご連絡ください。</p>
+    <dl>
+      <dt>対応言語</dt><dd>日本語</dd>
+      <dt>受付</dt><dd>平日 11:00-15:00 JST</dd>
+      <dt>データ保存</dt><dd>入力した書類・取引先・自社情報は端末内に保存されます。</dd>
+    </dl>
+  </section>
+  <section id="privacy-ja">
+    <h2>プライバシーポリシー / Privacy Policy</h2>
+    <p>見積・請求書作成 は、トラッキング、広告用識別子の収集、外部アカウント作成、クラウド同期を行いません。</p>
+    <p>請求書、見積書、取引先、自社情報、振込先などの入力データは、アプリのローカル保存領域に保存されます。PDF共有時は、利用者が選択した共有先にPDFが渡されます。</p>
+    <p>サポートにメールでお問い合わせいただいた場合、返信に必要な範囲でメールアドレスと問い合わせ内容を扱います。</p>
+  </section>
+  <section id="terms-ja">
+    <h2>利用条件</h2>
+    <p>本アプリは書類作成支援ツールです。税務・法務上の判断が必要な場合は、税理士・弁護士等の専門家に確認してください。</p>
+  </section>
+  <section id="contact-ja">
+    <h2>お問い合わせ</h2>
+    <p><a href="mailto:app-support@allnew.work">app-support@allnew.work</a></p>
+  </section>
+</main>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add app-specific hosted support/privacy page for FormFitInvoice at `/formfitinvoice/`
- include app name, support contact, privacy/data handling copy, and anchors used by ASC metadata

## Verification
- `rg -n "見積・請求書作成|Privacy|プライバシ|Support|サポート|app-support@allnew.work" formfitinvoice/index.html`
