### PR TITLE
fix(security): harden landing JSON-LD render + Vercel deploy CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,14 +23,20 @@ jobs:
         with:
           node-version: "24"
 
+      # Install the CLI in a step WITHOUT the Vercel secrets in env, so npm
+      # package lifecycle scripts (preinstall/install/postinstall) of vercel or
+      # any transitive dependency cannot read the production deploy token.
+      - name: Install Vercel CLI
+        run: |
+          node --version
+          npm --version
+          npm install --global vercel@50.40.0
+
       - name: Deploy to Vercel
         env:
           VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
         run: |
-          node --version
-          npm --version
-          npm install --global vercel@50.40.0
           vercel pull --yes --environment=production --token "$VERCEL_TOKEN"
           vercel deploy --prod --yes --token "$VERCEL_TOKEN"

--- a/.github/workflows/landing-auto-update.yml
+++ b/.github/workflows/landing-auto-update.yml
@@ -37,11 +37,24 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          # Do not persist GITHUB_TOKEN in .git/config: the deploy steps run the
+          # Vercel CLI, and a compromised CLI must not be able to reuse a
+          # write-capable git credential. The commit step pushes with an
+          # explicit, scoped token instead (see below).
+          persist-credentials: false
 
       - name: Setup Python
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: "3.12"
+
+      - name: Install Vercel CLI
+        # Exact pinned version installed WITHOUT the Vercel token in env, so npm
+        # lifecycle scripts cannot read it. Replaces `npx vercel@50` — an
+        # unpinned semver range that fetches and executes new CLI code at deploy
+        # time in the same step that holds VERCEL_TOKEN.
+        run: npm install --global vercel@50.40.0
 
       - name: Write event payload
         run: |
@@ -73,6 +86,10 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RECONCILE_INPUT: ${{ inputs.reconcile }}
           BOOTSTRAP_INPUT: ${{ inputs.bootstrap }}
+          # Write-capable token scoped to this commit step only (kept out of the
+          # Vercel deploy step's environment). checkout uses persist-credentials:
+          # false, so the push must supply this token explicitly.
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -120,7 +137,7 @@ jobs:
           # Retry push because repository_dispatch events can arrive in bursts.
           # On failure, rebuild from latest branch head with the same event payload.
           for attempt in 1 2 3; do
-            if git push origin "HEAD:${TARGET_BRANCH}"; then
+            if git push "https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "HEAD:${TARGET_BRANCH}"; then
               echo "Push succeeded on attempt ${attempt}"
               echo "changed=true" >> "${GITHUB_OUTPUT}"
               exit 0
@@ -157,7 +174,7 @@ jobs:
             echo "::error::VERCEL_TOKEN secret is not set. apps.allnew.work is served by Vercel; add the secret in repo settings."
             exit 1
           fi
-          npx --yes vercel@50 deploy --prod --yes --token "${VERCEL_TOKEN}"
+          vercel deploy --prod --yes --token "${VERCEL_TOKEN}"
 
       - name: Live verification (production readback, one self-heal redeploy)
         id: live-verify
@@ -180,7 +197,7 @@ jobs:
             exit 1
           fi
           echo "Live drift detected; redeploying production from committed main HEAD"
-          npx --yes vercel@50 deploy --prod --yes --token "${VERCEL_TOKEN}"
+          vercel deploy --prod --yes --token "${VERCEL_TOKEN}"
           verify --retries 8
 
       - name: ANDON — open issue on gate block or live drift

--- a/landing-automation/scripts/render_landing_page.py
+++ b/landing-automation/scripts/render_landing_page.py
@@ -58,6 +58,26 @@ def load_released_apps() -> list[dict]:
     return [app for app in apps if app.get("status") == "released"]
 
 
+def html_safe_json_dumps(payload: object) -> str:
+    """Serialize JSON for safe embedding inside an HTML ``<script>`` element.
+
+    ``json.dumps`` escapes ``"`` ``\\`` and control chars, but leaves ``<`` ``>``
+    ``&`` raw. HTML parses ``<script>`` content as raw text and terminates the
+    element at the first *case-insensitive* ``</script`` — even inside a JSON
+    string — so a value such as ``</ScRiPt>...`` would break out of the JSON-LD
+    block in the browser while still passing a naive lowercase-``</script>``
+    validator. Encoding these characters as JSON ``\\uXXXX`` escapes keeps the
+    payload valid JSON (``json.loads`` round-trips) yet makes it impossible to
+    close the element from string data.
+    """
+    return (
+        json.dumps(payload, ensure_ascii=False, indent=4)
+        .replace("<", "\\u003c")
+        .replace(">", "\\u003e")
+        .replace("&", "\\u0026")
+    )
+
+
 def build_json_ld(apps: list[dict]) -> str:
     items = []
     for position, app in enumerate(apps, start=1):
@@ -89,15 +109,18 @@ def build_json_ld(apps: list[dict]) -> str:
         "numberOfItems": len(apps),
         "itemListElement": items,
     }
-    return json.dumps(payload, ensure_ascii=False, indent=4)
+    return html_safe_json_dumps(payload)
 
 
 def replace_json_ld(page: str, json_ld: str) -> str:
     # スクリプトブロック単位で走査する。貪欲マッチで隣の JSON-LD
     # （Organization 等）を巻き込まないため、`</script>` を境界として
     # 各ブロックを個別に判定する。
+    # re.I: browsers close a <script> at the first case-insensitive </script>,
+    # so the block boundary must be matched case-insensitively too — otherwise a
+    # mixed-case </ScRiPt> inside data slips past both replace and validation.
     pattern = re.compile(
-        r'(<script type="application/ld\+json">)(.*?)(</script>)', re.S
+        r'(<script type="application/ld\+json">)(.*?)(</script>)', re.I | re.S
     )
     for match in pattern.finditer(page):
         body = match.group(2)
@@ -188,7 +211,7 @@ def main() -> None:
     # 検証: 全 JSON-LD ブロックがパース可能で、ItemList が期待件数であること
     # （feedback portal / status board は静的 JSON-LD を DOMParser で読む前提）
     blocks = re.findall(
-        r'<script type="application/ld\+json">(.*?)</script>', page, re.S
+        r'<script type="application/ld\+json">(.*?)</script>', page, re.I | re.S
     )
     item_lists = []
     for body in blocks:

--- a/landing-automation/tests/test_render_landing_page.py
+++ b/landing-automation/tests/test_render_landing_page.py
@@ -54,8 +54,11 @@ def test_all_json_ld_string_fields_are_escaped():
     assert item["alternateName"] == "日本<>"
 
 
-def test_replace_and_validate_survive_mixed_case_close_tag():
-    """replace_json_ld + the fail-closed validator both handle mixed-case."""
+def test_escaping_neutralizes_mixed_case_close_tag_in_data():
+    """A mixed-case </ScRiPt> inside a *description* is neutralized by the
+    output escaping (the real control), so replace_json_ld still produces one
+    clean, parseable block. (This asserts the escaping layer, not re.I —
+    test_replace_json_ld_matches_mixed_case_boundary covers re.I.)"""
     page = (
         "<html><head>"
         '<script type="application/ld+json">'
@@ -66,7 +69,6 @@ def test_replace_and_validate_survive_mixed_case_close_tag():
     json_ld = rlp.build_json_ld([_app(description_ja="</ScRiPt> boom")])
     replaced = rlp.replace_json_ld(page, json_ld)
 
-    # The case-insensitive validation regex must see exactly one clean block.
     blocks = re.findall(
         r'<script type="application/ld\+json">(.*?)</script>', replaced, re.I | re.S
     )
@@ -74,6 +76,30 @@ def test_replace_and_validate_survive_mixed_case_close_tag():
     parsed = json.loads(blocks[0])
     assert parsed["@type"] == "ItemList"
     assert parsed["numberOfItems"] == 1
+
+
+def test_replace_json_ld_matches_mixed_case_boundary():
+    """replace_json_ld must recognize the existing ItemList block even when its
+    closing tag is a mixed-case </ScRiPt> — this actually exercises the re.I
+    flag on the production block-matching regex. With re.S only (re.I removed),
+    the boundary is not matched and replace_json_ld raises 'block not found',
+    so this test fails if that defense-in-depth flag is ever reverted."""
+    page = (
+        "<html><head>"
+        '<script type="application/ld+json">'
+        '{"@type":"ItemList","numberOfItems":0,"itemListElement":[]}'
+        "</ScRiPt>"  # mixed-case boundary: re.S-only would not match this block
+        "</head><body></body></html>"
+    )
+    json_ld = rlp.build_json_ld([_app(description_ja="safe")])
+
+    replaced = rlp.replace_json_ld(page, json_ld)  # raises if re.I is missing
+
+    blocks = re.findall(
+        r'<script type="application/ld\+json">(.*?)</script>', replaced, re.I | re.S
+    )
+    assert len(blocks) == 1
+    assert json.loads(blocks[0])["numberOfItems"] == 1
 
 
 def test_benign_content_still_renders_valid_json_ld():

--- a/landing-automation/tests/test_render_landing_page.py
+++ b/landing-automation/tests/test_render_landing_page.py
@@ -1,0 +1,84 @@
+"""Regression tests for safe JSON-LD rendering in render_landing_page.
+
+Guards the script-context output-encoding + case-insensitive block matching
+that stop an App Store description from breaking out of the
+``<script type="application/ld+json">`` element. The source of these fields is
+AllNew's own App Store metadata (self-authored), so this is defense-in-depth,
+but the encoding must be correct regardless of who writes the value.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+
+import render_landing_page as rlp
+
+
+def _app(**overrides):
+    app = {
+        "slug": "probe",
+        "name": "Probe",
+        "name_ja": "プローブ",
+        "description_ja": "safe description",
+        "category": "productivity",
+        "icon_path": "probe-icon.png",
+        "app_store_url": "https://apps.apple.com/jp/app/x/id123",
+    }
+    app.update(overrides)
+    return app
+
+
+def test_json_ld_escapes_script_breakout_chars():
+    """A mixed-case </ScRiPt> in a description cannot terminate the block."""
+    payload = "</ScRiPt><script>alert(1)</sCrIpT> & <img src=x onerror=alert(1)>"
+    json_ld = rlp.build_json_ld([_app(description_ja=payload)])
+
+    # No raw script-context-significant characters survive in the block.
+    assert "<" not in json_ld
+    assert ">" not in json_ld
+    assert "&" not in json_ld
+    # No case-insensitive </script terminator can appear anywhere.
+    assert re.search(r"</script", json_ld, re.I) is None
+    # Round-trips: the escaped value parses back to the original text.
+    parsed = json.loads(json_ld)
+    assert parsed["itemListElement"][0]["item"]["description"] == payload
+
+
+def test_all_json_ld_string_fields_are_escaped():
+    """Escaping covers name/alternateName, not just description."""
+    json_ld = rlp.build_json_ld([_app(name="A<b>&", name_ja="日本<>")])
+    assert "<" not in json_ld and ">" not in json_ld and "&" not in json_ld
+    item = json.loads(json_ld)["itemListElement"][0]["item"]
+    assert item["name"] == "A<b>&"
+    assert item["alternateName"] == "日本<>"
+
+
+def test_replace_and_validate_survive_mixed_case_close_tag():
+    """replace_json_ld + the fail-closed validator both handle mixed-case."""
+    page = (
+        "<html><head>"
+        '<script type="application/ld+json">'
+        '{"@type":"ItemList","numberOfItems":0,"itemListElement":[]}'
+        "</script>"
+        "</head><body></body></html>"
+    )
+    json_ld = rlp.build_json_ld([_app(description_ja="</ScRiPt> boom")])
+    replaced = rlp.replace_json_ld(page, json_ld)
+
+    # The case-insensitive validation regex must see exactly one clean block.
+    blocks = re.findall(
+        r'<script type="application/ld\+json">(.*?)</script>', replaced, re.I | re.S
+    )
+    assert len(blocks) == 1
+    parsed = json.loads(blocks[0])
+    assert parsed["@type"] == "ItemList"
+    assert parsed["numberOfItems"] == 1
+
+
+def test_benign_content_still_renders_valid_json_ld():
+    """Ordinary descriptions round-trip unchanged (no over-escaping breakage)."""
+    json_ld = rlp.build_json_ld([_app(description_ja="血圧を記録")])
+    parsed = json.loads(json_ld)
+    assert parsed["numberOfItems"] == 1
+    assert parsed["itemListElement"][0]["item"]["description"] == "血圧を記録"


### PR DESCRIPTION
## Summary

Addresses three Codex Cloud security findings on `mueno/allnew-apps`, verified against **current** code (the reported commits were older; the vulnerable patterns are still present on `main`).

### 1. JSON-LD can be broken out of / script injection — `render_landing_page.py`
- `build_json_ld()` now escapes `<` `>` `&` to `\uXXXX` in the serialized `application/ld+json` payload, and the replace + fail-closed validation regexes now match the `</script>` block boundary **case-insensitively** (`re.I`).
- Without this, a description containing a mixed-case `</ScRiPt>` would close the `<script>` element in the browser (which matches close tags case-insensitively) while sailing past the validator (which only looked for lowercase `</script>`), landing an injected `<img onerror>`/`<script>` in the live DOM. CSP allows `script-src 'unsafe-inline'`, so it is not a backstop.
- **Real-world severity: low.** The only writer of these fields is AllNew's *own* App Store metadata — `store_discovery.py` queries the iTunes Lookup API for a single `artist_id` (1875164184), so this is self-authored content, **not** third-party/anonymous input as the finding assumed. Weaponizing it requires compromising AllNew's App Store Connect account. This is correct output-encoding hardening (defense-in-depth), not an emergency.
- Added `landing-automation/tests/test_render_landing_page.py` as a regression guard.

### 2. Unpinned `npx vercel@50` in the privileged auto-update workflow — `landing-auto-update.yml`
- `npx --yes vercel@50` (an unpinned semver **range**) was fetched and executed at deploy time **twice**, in steps that hold `VERCEL_TOKEN`, inside a job with `contents: write` + `deployments: write` and default-persisted git credentials.
- Now: the CLI is installed once at an **exact pin** (`vercel@50.40.0`) in a **secret-free** step; both deploy sites call the installed `vercel`. `actions/checkout` sets `persist-credentials: false`; the commit step pushes with an explicit, commit-step-scoped `GH_TOKEN` so a compromised deploy-time CLI cannot reuse the write-capable `GITHUB_TOKEN`.

### 3. Vercel token exposed to npm install scripts — `deploy.yml`
- `npm install --global vercel@50.40.0` ran in the same step as `VERCEL_TOKEN`/`VERCEL_ORG_ID`/`VERCEL_PROJECT_ID`, so any package lifecycle script (preinstall/install/postinstall) inherited the production secrets.
- Now: install runs in its own step with **no** Vercel secrets in env; only `vercel pull/deploy` sees the token.

## Testing
- `python3 -m pytest landing-automation/tests -q` → **71 passed** (4 new + 67 existing).
- Verified the renderer produces valid, escaped, round-tripping JSON-LD against live `data/landing-apps.generated.json` (15 released apps).
- Both workflow YAMLs parse; no residual `npx` / `git push origin`.

## Notes / residual (not blocking)
- Global installs don't pin transitive deps (no lockfile for `-g`); the exact top-level pin is the practical bound. Optional further hardening: `--ignore-scripts` on the install, or the SHA-pinned official `vercel-action`.
- `index.html` is intentionally **not** regenerated here — the committed page reflects current benign data; the renderer (the actual sink) is what's fixed, and CI regenerates the page on the next run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
