### PR TITLE
feat(nekomeal): publish the hosted legal/support page

### DIFF
--- a/nekomeal/index.html
+++ b/nekomeal/index.html
@@ -1,0 +1,640 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>NekoMeal Support</title>
+  <meta name="description" content="Legal and support page for NekoMeal, including Privacy Policy, Terms of Service, commercial disclosure, and contact details.">
+  <meta http-equiv="Content-Security-Policy" content="default-src 'none'; style-src 'unsafe-inline'; img-src 'self' data:; script-src 'unsafe-inline'; form-action 'none'; base-uri 'self'">
+  <meta name="referrer" content="no-referrer">
+  <meta name="robots" content="noindex, nofollow, noarchive, nosnippet, noimageindex">
+  <meta name="googlebot" content="noindex, nofollow, noarchive, nosnippet">
+  <meta name="bingbot" content="noindex, nofollow, noarchive">
+  <meta name="GPTBot" content="noindex, nofollow">
+  <meta name="CCBot" content="noindex, nofollow">
+  <meta name="anthropic-ai" content="noindex, nofollow">
+  <meta name="Google-Extended" content="noindex, nofollow">
+  <style>
+    :root {
+      --bg-primary: #fafafa;
+      --bg-secondary: #ffffff;
+      --bg-tertiary: #f5f5f7;
+      --text-primary: #1d1d1f;
+      --text-secondary: #6e6e73;
+      --text-tertiary: #86868b;
+      --accent: #279679;
+      --accent-hover: #1f7f67;
+      --border: rgba(0,0,0,0.08);
+      --glass: rgba(255,255,255,0.72);
+      --shadow-soft: 0 4px 24px rgba(0,0,0,0.06);
+      --radius-sm: 12px;
+      --radius-lg: 28px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg-primary: #000000;
+        --bg-secondary: #1c1c1e;
+        --bg-tertiary: #2c2c2e;
+        --text-primary: #f5f5f7;
+        --text-secondary: #a1a1a6;
+        --text-tertiary: #6e6e73;
+        --accent: #62d1b4;
+        --accent-hover: #7ee0c8;
+        --border: rgba(255,255,255,0.1);
+        --glass: rgba(28,28,30,0.72);
+        --shadow-soft: 0 4px 24px rgba(0,0,0,0.3);
+      }
+    }
+    * { margin: 0; padding: 0; box-sizing: border-box; }
+    html { scroll-behavior: smooth; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Hiragino Sans", sans-serif;
+      background: var(--bg-primary);
+      color: var(--text-primary);
+      line-height: 1.6;
+      -webkit-font-smoothing: antialiased;
+    }
+    .header {
+      position: sticky;
+      top: 0;
+      z-index: 100;
+      padding: 12px 20px;
+      background: var(--glass);
+      backdrop-filter: saturate(180%) blur(20px);
+      -webkit-backdrop-filter: saturate(180%) blur(20px);
+      border-bottom: 1px solid var(--border);
+    }
+    .header-inner {
+      max-width: 800px;
+      margin: 0 auto;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      gap: 16px;
+    }
+    .logo-link {
+      color: var(--text-primary);
+      text-decoration: none;
+      display: flex;
+      align-items: center;
+      gap: 12px;
+      min-width: 0;
+    }
+    .logo { font-size: 1.2rem; font-weight: 600; letter-spacing: 0; }
+    .logo-divider { width: 1px; height: 18px; background: var(--border); }
+    .app-name {
+      font-size: 0.85rem;
+      color: var(--text-secondary);
+      font-weight: 500;
+      overflow: hidden;
+      text-overflow: ellipsis;
+      white-space: nowrap;
+    }
+    .lang-dropdown { position: relative; flex-shrink: 0; }
+    .lang-btn {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      padding: 8px 14px;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border);
+      border-radius: 980px;
+      font-size: 0.85rem;
+      font-weight: 500;
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+    .lang-btn::after {
+      content: "";
+      width: 0;
+      height: 0;
+      border-left: 4px solid transparent;
+      border-right: 4px solid transparent;
+      border-top: 5px solid var(--text-secondary);
+    }
+    .lang-menu {
+      display: none;
+      position: absolute;
+      top: calc(100% + 8px);
+      right: 0;
+      min-width: 160px;
+      background: var(--bg-secondary);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-sm);
+      box-shadow: var(--shadow-soft);
+      overflow: hidden;
+      z-index: 200;
+    }
+    .lang-dropdown.open .lang-menu { display: block; }
+    .lang-option {
+      display: block;
+      width: 100%;
+      padding: 12px 16px;
+      border: 0;
+      background: transparent;
+      text-align: left;
+      font-size: 0.9rem;
+      color: var(--text-primary);
+      cursor: pointer;
+    }
+    .lang-option.active, .lang-option:hover {
+      background: var(--bg-tertiary);
+      color: var(--accent);
+    }
+    .hero {
+      text-align: center;
+      padding: 60px 20px 40px;
+      background: linear-gradient(180deg, var(--bg-primary) 0%, var(--bg-secondary) 100%);
+    }
+    .hero-icon {
+      width: 80px;
+      height: 80px;
+      border-radius: 18px;
+      margin: 0 auto 20px;
+      box-shadow: 0 8px 32px rgba(0,0,0,0.15);
+      object-fit: cover;
+      display: block;
+    }
+    .hero-icon:hover { animation: wiggle 0.5s ease; }
+    @keyframes wiggle {
+      0%, 100% { transform: rotate(0deg); }
+      25% { transform: rotate(-5deg) scale(1.05); }
+      75% { transform: rotate(5deg) scale(1.05); }
+    }
+    .hero h1 { font-size: 2rem; font-weight: 700; letter-spacing: 0; margin-bottom: 8px; }
+    .hero-subtitle { font-size: 1rem; color: var(--text-secondary); }
+    .toc {
+      display: flex;
+      justify-content: center;
+      gap: 8px;
+      padding: 16px 20px;
+      background: var(--bg-secondary);
+      border-bottom: 1px solid var(--border);
+      flex-wrap: wrap;
+    }
+    .toc-link {
+      padding: 8px 16px;
+      color: var(--text-secondary);
+      text-decoration: none;
+      font-size: 0.85rem;
+      font-weight: 500;
+      border-radius: 980px;
+    }
+    .toc-link:hover { background: var(--bg-tertiary); color: var(--text-primary); }
+    .main { max-width: 800px; margin: 0 auto; padding: 0 20px 80px; }
+    .section {
+      padding: 48px 0;
+      border-bottom: 1px solid var(--border);
+      scroll-margin-top: 80px;
+    }
+    .section:last-child { border-bottom: none; }
+    .section-header {
+      display: flex;
+      align-items: center;
+      gap: 16px;
+      margin-bottom: 24px;
+    }
+    .section-icon {
+      width: 48px;
+      height: 48px;
+      background: var(--bg-tertiary);
+      border-radius: 14px;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      font-size: 24px;
+      flex-shrink: 0;
+    }
+    .section-title { font-size: 1.4rem; font-weight: 600; letter-spacing: 0; }
+    .section-subtitle { font-size: 0.85rem; color: var(--text-secondary); margin-top: 2px; }
+    .faq-item {
+      background: var(--bg-secondary);
+      border-radius: var(--radius-sm);
+      margin-bottom: 8px;
+      border: 1px solid var(--border);
+      overflow: hidden;
+    }
+    .faq-question {
+      padding: 18px 24px;
+      font-weight: 500;
+      cursor: pointer;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 16px;
+      font-size: 0.95rem;
+      color: var(--text-primary);
+    }
+    .faq-question:hover { background: var(--bg-tertiary); }
+    .faq-icon {
+      width: 24px;
+      height: 24px;
+      border-radius: 50%;
+      background: var(--bg-tertiary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--accent);
+      font-size: 18px;
+      font-weight: 300;
+      flex-shrink: 0;
+    }
+    .faq-answer { max-height: 0; overflow: hidden; transition: max-height 0.25s ease, padding 0.25s ease; }
+    .faq-item.open .faq-answer { max-height: 800px; padding: 0 24px 24px; }
+    .faq-item.open .faq-icon { background: var(--accent); color: white; transform: rotate(45deg); }
+    .faq-answer p {
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      line-height: 1.8;
+      margin-bottom: 12px;
+    }
+    .legal-section { margin-bottom: 28px; }
+    .legal-section h3 {
+      font-size: 1rem;
+      font-weight: 600;
+      color: var(--text-primary);
+      margin-bottom: 12px;
+      display: flex;
+      align-items: center;
+      gap: 10px;
+    }
+    .legal-section h3::before {
+      content: "";
+      width: 4px;
+      height: 18px;
+      background: var(--accent);
+      border-radius: 2px;
+      flex-shrink: 0;
+    }
+    .legal-section h4 {
+      color: var(--text-primary);
+      font-size: 0.95rem;
+      margin: 18px 0 8px;
+    }
+    .legal-section p, .legal-section li {
+      color: var(--text-secondary);
+      font-size: 0.9rem;
+      line-height: 1.8;
+      margin-bottom: 12px;
+    }
+    .legal-section ul, .legal-section ol { padding-left: 20px; }
+    .legal-section a { color: var(--accent); text-decoration: none; }
+    .legal-section a:hover { text-decoration: underline; }
+    table { width: 100%; border-collapse: collapse; margin: 14px 0; overflow-wrap: anywhere; }
+    th, td { border-bottom: 1px solid var(--border); text-align: left; vertical-align: top; padding: 9px 6px; }
+    .commercial-accordion {
+      background: var(--bg-secondary);
+      border-radius: var(--radius-sm);
+      border: 1px solid var(--border);
+      overflow: hidden;
+    }
+    .commercial-header {
+      width: 100%;
+      appearance: none;
+      border: 0;
+      background: transparent;
+      color: inherit;
+      display: flex;
+      align-items: center;
+      justify-content: space-between;
+      padding: 20px 24px;
+      cursor: pointer;
+      text-align: left;
+    }
+    .commercial-header:hover { background: var(--bg-tertiary); }
+    .commercial-header .section-header { margin-bottom: 0; }
+    .commercial-toggle {
+      width: 28px;
+      height: 28px;
+      border-radius: 50%;
+      background: var(--bg-tertiary);
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      color: var(--accent);
+      font-size: 20px;
+      font-weight: 300;
+      flex-shrink: 0;
+    }
+    .commercial-accordion.open .commercial-toggle { background: var(--accent); color: white; transform: rotate(45deg); }
+    .commercial-content { max-height: 0; overflow: hidden; transition: max-height 0.3s ease; }
+    .commercial-accordion.open .commercial-content { max-height: 1400px; padding: 0 24px 24px; }
+    .contact-card {
+      background: linear-gradient(135deg, var(--bg-secondary) 0%, var(--bg-tertiary) 100%);
+      border-radius: var(--radius-lg);
+      padding: 40px;
+      text-align: center;
+      border: 1px solid var(--border);
+    }
+    .contact-card h2 { font-size: 1.4rem; font-weight: 600; margin-bottom: 22px; }
+    .contact-email {
+      display: inline-flex;
+      align-items: center;
+      gap: 10px;
+      background: var(--accent);
+      color: white;
+      padding: 14px 28px;
+      border-radius: 980px;
+      text-decoration: none;
+      font-weight: 500;
+      font-size: 0.95rem;
+    }
+    .contact-email:hover { background: var(--accent-hover); transform: scale(1.02); }
+    .contact-details {
+      margin-top: 32px;
+      padding-top: 24px;
+      border-top: 1px solid var(--border);
+      text-align: left;
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+      gap: 16px;
+    }
+    .contact-details-top {
+      margin-top: 24px;
+      margin-bottom: 24px;
+      padding-top: 0;
+      padding-bottom: 16px;
+      border-top: none;
+      border-bottom: 1px solid var(--border);
+    }
+    .contact-item { font-size: 0.85rem; }
+    .contact-item dt { color: var(--text-tertiary); font-weight: 500; margin-bottom: 4px; }
+    .contact-item dd { color: var(--text-primary); margin: 0; overflow-wrap: anywhere; }
+    .muted { color: var(--text-tertiary); }
+    [data-lang="en"] { display: none; }
+    body.lang-en [data-lang="ja"] { display: none; }
+    body.lang-en [data-lang="en"] { display: block; }
+    @media (max-width: 640px) {
+      .header-inner { gap: 12px; }
+      .app-name { max-width: 150px; }
+      .hero { padding: 40px 20px 30px; }
+      .hero h1 { font-size: 1.6rem; }
+      .toc { gap: 4px; }
+      .toc-link { padding: 6px 12px; font-size: 0.8rem; }
+      .section { padding: 32px 0; }
+      .section-header { flex-direction: column; text-align: center; }
+      .commercial-header .section-header { flex-direction: row; text-align: left; }
+      .contact-card { padding: 28px; }
+      .contact-details { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <header class="header">
+    <div class="header-inner">
+      <a href="../" class="logo-link" aria-label="AllNew NekoMeal">
+        <span class="logo">AllNew</span>
+        <span class="logo-divider" aria-hidden="true"></span>
+        <span class="app-name" data-lang="ja">NekoMeal</span>
+        <span class="app-name" data-lang="en">NekoMeal</span>
+      </a>
+      <div class="lang-dropdown" id="langDropdown">
+        <button class="lang-btn" type="button" onclick="toggleLangMenu()" aria-haspopup="true" aria-expanded="false"><span id="currentLang">日本語</span></button>
+        <div class="lang-menu" role="menu">
+          <button class="lang-option" type="button" data-lang-option="ja" onclick="setLang('ja')" role="menuitem">日本語</button>
+          <button class="lang-option" type="button" data-lang-option="en" onclick="setLang('en')" role="menuitem">English</button>
+        </div>
+      </div>
+    </div>
+  </header>
+
+  <section class="hero" data-lang="ja">
+    <img src="data:image/svg+xml,%3Csvg xmlns=&#x27;http://www.w3.org/2000/svg&#x27; viewBox=&#x27;0 0 1024 1024&#x27;%3E%3Crect width=&#x27;1024&#x27; height=&#x27;1024&#x27; rx=&#x27;220&#x27; fill=&#x27;%23f5f5f7&#x27;/%3E%3Ctext x=&#x27;512&#x27; y=&#x27;610&#x27; font-size=&#x27;420&#x27; text-anchor=&#x27;middle&#x27; font-family=&#x27;-apple-system,BlinkMacSystemFont,Arial&#x27; fill=&#x27;%236e6e73&#x27;%3Ei%3C/text%3E%3C/svg%3E" alt="NekoMeal" class="hero-icon">
+    <h1>NekoMeal</h1>
+    <p class="hero-subtitle">プライバシーポリシー、利用規約、<br>特定商取引法に基づく表記。</p>
+  </section>
+  <section class="hero" data-lang="en">
+    <img src="data:image/svg+xml,%3Csvg xmlns=&#x27;http://www.w3.org/2000/svg&#x27; viewBox=&#x27;0 0 1024 1024&#x27;%3E%3Crect width=&#x27;1024&#x27; height=&#x27;1024&#x27; rx=&#x27;220&#x27; fill=&#x27;%23f5f5f7&#x27;/%3E%3Ctext x=&#x27;512&#x27; y=&#x27;610&#x27; font-size=&#x27;420&#x27; text-anchor=&#x27;middle&#x27; font-family=&#x27;-apple-system,BlinkMacSystemFont,Arial&#x27; fill=&#x27;%236e6e73&#x27;%3Ei%3C/text%3E%3C/svg%3E" alt="NekoMeal" class="hero-icon">
+    <h1>NekoMeal</h1>
+    <p class="hero-subtitle">Privacy Policy, Terms of Service,<br>commercial disclosure, and support.</p>
+  </section>
+
+  <nav class="toc" data-lang="ja">
+<a class="toc-link" href="#faq-ja">FAQ</a>
+<a class="toc-link" href="#privacy-ja">プライバシー</a>
+<a class="toc-link" href="#terms-ja">利用規約</a>
+<a class="toc-link" href="#oss-ja">3rd Party Licensing Notice</a>
+<a class="toc-link" href="#commercial-ja">特定商取引法</a>
+<a class="toc-link" href="#contact-ja">お問い合わせ</a>
+</nav>
+  <nav class="toc" data-lang="en">
+<a class="toc-link" href="#faq-en">FAQ</a>
+<a class="toc-link" href="#privacy-en">Privacy</a>
+<a class="toc-link" href="#terms-en">Terms</a>
+<a class="toc-link" href="#oss-en">3rd Party Licensing Notice</a>
+<a class="toc-link" href="#commercial-en">Commercial</a>
+<a class="toc-link" href="#contact-en">Contact</a>
+</nav>
+
+  <main class="main">
+    <section id="faq-ja" class="section" data-lang="ja"><div class="section-header"><div class="section-icon">💡</div><div><div class="section-title">よくある質問</div><div class="section-subtitle">使い方や機能についてお答えします</div></div></div><div class="legal-section"><div class="faq-item open"><div class="faq-question">バックアップは自動ですか？<span class="faq-icon">+</span></div><div class="faq-answer"><p>書類・取引先・会社情報を更新すると、復元用の控えをアプリ内で自動作成します。端末移行やアプリ削除前など必要な場合だけ、保管用ファイルとして共有できます。</p></div></div></div></section>
+    <section id="faq-en" class="section" data-lang="en"><div class="section-header"><div class="section-icon">💡</div><div><div class="section-title">FAQ</div><div class="section-subtitle">Questions about using the app</div></div></div><div class="legal-section"><div class="faq-item open"><div class="faq-question">Are backups automatic?<span class="faq-icon">+</span></div><div class="faq-answer"><p>When documents, clients, or company profile change, the app automatically creates an in-app recovery copy. You can share a safekeeping file only when needed, such as before device migration or app deletion.</p></div></div></div></section>
+    <section id="privacy-ja" class="section" data-lang="ja"><div class="section-header"><div class="section-icon">🔒</div><div><div class="section-title">プライバシーポリシー</div><div class="section-subtitle">データの取り扱い</div></div></div><div class="legal-section"><p>最終更新日: 2026-07-28</p>
+<p>重要: 本アプリは、ユーザーデータを当社の外部サーバーへ送信・保存しません。</p>
+<p>合同会社AllNew（以下「当社」）は、正式名称「NekoMeal」、日本語のApp Store表示名「NekoMeal」（以下「本アプリ」）におけるユーザー情報の取り扱いについて本ポリシーを定めます。当社の名称、住所、代表者等の事業者情報は、特定商取引法に基づく表示をご確認ください。</p>
+<h3>1. 取り扱う情報</h3>
+<p>当社は、本アプリを提供するために、次の情報を取り扱う場合があります。</p>
+<h3>(A) 端末内データ</h3>
+<ul><li>本アプリで作成、保存、管理されるデータは、ユーザーの端末内で処理されます。</li><li>当社は、当該データを当社が運用する外部サーバーへ送信・保存しません。</li></ul>
+<h3>(B) 写真・カメラ入力</h3>
+<ul><li>本アプリはカメラまたは写真ライブラリを、ユーザーが明示的に選択した撮影、読み取り、記録補助のためにのみ使用します。撮影画像や選択画像は端末内で扱われ、プライバシーポリシーに明記した場合を除き、当社サーバーへ送信・保存しません。</li></ul>
+<h3>(C) お問い合わせ情報（サポート）</h3>
+<ul><li>ユーザーがメール等で問い合わせを行う場合、メールアドレス、問い合わせ内容、ユーザーが任意で提供した情報（端末情報等）を受領します。</li></ul>
+<h3>(D) 購入に関する情報</h3>
+<ul><li>有料機能や購読の購入処理はAppleのStoreKit/App Store決済により行われます。当社はユーザーのクレジットカード番号を取得しません。</li></ul>
+<h3>2. 利用目的</h3>
+<p>当社は、上記情報を以下の目的で利用します。</p>
+<ul><li>本アプリの機能提供（NekoMealは、見積書・請求書などの業務書類を作成・管理するためのアプリです。）</li><li>サポート対応、問い合わせへの返信</li><li>不具合調査・品質改善（ユーザーが提供した範囲に限る）</li><li>法令遵守・紛争対応</li></ul>
+<h3>3. 第三者提供・外部送信</h3>
+<ul><li>本アプリで作成、保存、管理される端末内データは、ユーザーの端末内で処理され、当社が運用する外部サーバーまたは外部処理サービスへ送信・保存しません。</li><li>当社は、お問い合わせ情報等を、サポート対応、不具合調査、法令遵守・紛争対応のために必要な範囲でのみ取り扱います。</li><li>当社は、お問い合わせ情報等を、ユーザーの同意なく第三者へ提供しません。ただし、法令に基づく場合等を除きます。</li><li>当社は、本アプリに関連して取り扱う情報を広告・マーケティング・プロファイリング目的で利用せず、第三者へ販売・貸与等もしません。</li><li>当社は、ユーザーの端末内データを広告・マーケティング・プロファイリング目的で利用せず、第三者へ販売・貸与等もしません。</li><li>写真、ファイル、OS側の保存・同期は、ユーザーの端末設定およびAppleの仕様に従います。当社はAppleの挙動を制御できません。</li><li>当社はiOSアプリ内に利用状況解析のための外部プログラム（アナリティクスSDK）を導入していません。</li><li>本サポートサイトは、当社サポートサイトの運営基盤サービス（Vercel Inc.、米国）で運営され、設定有効時に当社サポートサイトの利用状況を集計するサービス（Vercel Web Analytics、Vercel Inc.、米国）を使用する場合があります。Vercel Web AnalyticsはCookie（ブラウザに保存される小さなデータ）を使用せず、個人を特定する情報を収集しません。ページビュー数、参照元、デバイスの種類などの集計データのみを収集します。</li></ul>
+<h3>4. 保管期間</h3>
+<ul><li>お問い合わせ情報は、原則として対応完了後12か月以内に削除します。</li><li>ただし、未解決の問い合わせ、紛争対応、法令上の保存義務がある場合は、必要な期間保管する場合があります。</li><li>本アプリで作成、保存、管理されるデータはユーザーの端末上で管理され、当社は当社サーバー上に保管しません。</li></ul>
+<h3>5. セキュリティ</h3>
+<p>当社は、お問い合わせ対応等で取り扱う情報について、合理的な安全管理措置を講じます。端末内データは、iOSおよびAppleの仕組みにより保護されます（詳細はユーザーの端末設定およびAppleの仕様に依存します）。</p>
+<h3>6. ユーザーの権利</h3>
+<p>当社が保有するお問い合わせ情報等について、ユーザーは、適用法令の範囲で、開示・訂正・削除等を求めることができます。ご希望は本ページ下部の「お問い合わせ」セクションからご連絡ください。</p>
+<p>※当社は端末内データを当社サーバー上に保有しないため、写真、ファイル、アプリ内データ等はユーザーの端末上で管理・削除してください。</p>
+<ul><li>すべてのユーザー: 端末内データの管理・削除は、本アプリ、iOSの写真アプリ、ファイルアプリ、またはiOS設定から行えます。表示項目はiOSバージョンにより異なる場合があります。</li><li>EU/EEA居住者（General Data Protection Regulation、以下「GDPR」）: 苦情申立て権、同意の撤回権。</li><li>カリフォルニア州居住者（California Consumer Privacy Act / California Privacy Rights Act、以下「CCPA/CPRA」）: 知る権利、削除権、オプトアウト権。</li><li>中国居住者（PIPL）: 知る権利、閲覧・複製権、削除権。Apple側の同期サービスをユーザーが有効にした場合、Appleの仕様に従ってユーザーの国・地域外で処理／保存される可能性があります。</li><li>韓国居住者（PIPA）: 処理中止要求権。</li><li>ブラジル居住者（LGPD）: データ移行要求権。</li></ul>
+<h3>7. 子どものプライバシー</h3>
+<p>本アプリは13歳未満（または居住国の最低年齢）の子どもを対象としていません。</p>
+<h3>8. 改定</h3>
+<p>当社は必要に応じて本ポリシーを改定します。改定後は当社サイト等で公表します。</p>
+<h3>9. お問い合わせ</h3>
+<p>お問い合わせ、開示・訂正・削除等のご請求は、本ページ下部の「お問い合わせ」セクションからご連絡ください。</p>
+<h3>10. 準拠法と管轄</h3>
+<p>本ポリシーは日本法を準拠法とします。各地域の居住者には該当する法律（GDPR、CCPA/CPRA、PIPL、LGPD、PIPA）が適用されます。</p>
+<h3>11. 多言語版について</h3>
+<p>本プライバシーポリシーは日本語を正文とします。他言語版との間に矛盾がある場合、日本語版を優先します。ただし、この規定は各居住国・地域の消費者保護法その他の強行法規に基づくユーザーの権利を制限するものではありません。</p>
+<p>---</p>
+<p>運営: 合同会社AllNew</p>
+<p>Apple、iPhone、iOS、App Storeは、米国およびその他の国で登録されたApple Inc.の商標です。その他の会社名・製品名は各社の商標または登録商標です。</p>
+<p>© 2026 合同会社AllNew</p></div></section>
+    <section id="privacy-en" class="section" data-lang="en"><div class="section-header"><div class="section-icon">🔒</div><div><div class="section-title">Privacy Policy</div><div class="section-subtitle">Data handling</div></div></div><div class="legal-section"><p>Last Updated: 2026-07-28</p>
+<p>Important: This app does not transmit or store user data on our servers.</p>
+<p>This Privacy Policy explains how AllNew LLC (&quot;we&quot;) handles information in the NekoMeal app (Japanese App Store display name: NekoMeal; the &quot;App&quot;). For our company name, address, and representative details, please refer to our Legal Notice (Specified Commercial Transactions Act disclosure).</p>
+<h3>1. Information We Handle</h3>
+<h3>(A) On-device data</h3>
+<ul><li>Data created, captured, saved, or managed in the App is processed on your device.</li><li>We do not transmit or store that data on servers operated by us.</li></ul>
+<h3>(B) Photo and camera input</h3>
+<ul><li>The App uses the camera or photo library only when you explicitly choose to capture, read, or attach records. Captured or selected images are handled on device and are not transmitted to or stored on our servers unless expressly described in this Privacy Policy.</li></ul>
+<h3>(C) Support communications</h3>
+<ul><li>If you email us, we may receive your email address, message content, and any information you include (e.g., device details), and use it to respond.</li></ul>
+<h3>(D) Purchases</h3>
+<ul><li>Paid features and subscriptions are processed through Apple&#x27;s StoreKit/App Store payment system. We do not receive your card numbers or similar payment credentials.</li></ul>
+<h3>2. Purposes</h3>
+<p>We use information only to:</p>
+<ul><li>Provide app functionality (NekoMeal helps create and manage estimates, invoices, and related business documents.)</li><li>Respond to support requests</li><li>Troubleshoot issues (based on what you provide)</li><li>Comply with law</li></ul>
+<h3>3. Sharing and External Transmission</h3>
+<ul><li>App data created, saved, or managed in the App is processed on your device. We do not transmit or store it on servers operated by us or external processing services.</li><li>We handle support communications only as necessary to respond, troubleshoot, comply with law, or address disputes.</li><li>We do not provide support communications to third parties without your consent, except where required by law.</li><li>We do not use on-device user data for advertising, marketing profiling, or data brokerage, and we do not sell such data.</li><li>Photo, file, and other Apple-managed storage/sync behavior depends on your device settings and Apple&#x27;s system behavior. We do not control Apple&#x27;s behavior.</li><li>We do not use any external analytics software development kit (SDK) in the iOS App.</li><li>This support website may be hosted by our website hosting provider (Vercel Inc., USA) and may use our support website aggregate usage measurement service (Vercel Web Analytics, Vercel Inc., USA) when enabled. Vercel Web Analytics is cookie-free and does not collect personally identifiable information. It only collects aggregate data such as page views, referrers, and device types.</li></ul>
+<h3>4. Retention</h3>
+<ul><li>Support emails are retained for up to 12 months after resolution, unless longer retention is required for disputes or legal obligations.</li><li>Data created, captured, saved, or managed in the App is stored on your device. We do not retain it on our servers.</li></ul>
+<h3>5. Security</h3>
+<p>We employ reasonable security measures for support communications we handle. On-device data is protected by iOS and Apple&#x27;s systems (details depend on your device settings and Apple&#x27;s specifications).</p>
+<h3>6. Your Rights</h3>
+<p>Where applicable, you may request access, correction, or deletion of support information we hold. Please contact us from the Contact section at the bottom of this page.</p>
+<p>Note: Since we do not retain on-device data on our servers, please manage or delete photos, files, and app data on your device.</p>
+<ul><li>All users: You can manage or delete on-device data through the App, iOS Photos, Files, or iOS Settings. Navigation paths may vary depending on your iOS version.</li><li>EU/EEA (General Data Protection Regulation, &quot;GDPR&quot;): Right to lodge complaints, withdraw consent.</li><li>California (California Consumer Privacy Act / California Privacy Rights Act, &quot;CCPA/CPRA&quot;): Right to know, delete, opt-out. We don&#x27;t sell personal information.</li><li>China (PIPL): Right to know, access, correct, delete. If you enable Apple services enabled in system settings, Apple&#x27;s systems may process or store data outside your country/region according to Apple&#x27;s specifications.</li><li>South Korea (PIPA): Right to request processing suspension.</li><li>Brazil (LGPD): Right to data portability.</li></ul>
+<h3>7. Children&#x27;s Privacy</h3>
+<p>This App is not intended for children under 13 (or the minimum age in your country of residence).</p>
+<h3>8. Changes to This Policy</h3>
+<p>We may update this Privacy Policy as needed. Changes will be posted on our website.</p>
+<h3>9. Contact</h3>
+<p>For support requests or privacy-related requests, please contact us from the Contact section at the bottom of this page.</p>
+<h3>10. Governing Law</h3>
+<p>This policy is governed by Japanese law. Regional laws (GDPR, CCPA/CPRA, PIPL, LGPD, PIPA) apply to respective residents.</p>
+<h3>11. Translations</h3>
+<p>The Japanese version of this Privacy Policy is the authoritative text. In case of any conflict between translated versions and the Japanese version, the Japanese version shall prevail. However, this does not limit your rights under mandatory consumer protection laws or other applicable regulations in your country or region of residence.</p>
+<p>---</p>
+<p>Operator: AllNew LLC</p>
+<p>Apple, iPhone, iOS, and App Store are trademarks of Apple Inc., registered in the U.S. and other countries. Other company and product names may be trademarks of their respective owners.</p>
+<p>© 2026 AllNew LLC</p></div></section>
+    <section id="terms-ja" class="section" data-lang="ja"><div class="section-header"><div class="section-icon">📜</div><div><div class="section-title">利用規約</div><div class="section-subtitle">サービスのご利用条件</div></div></div><div class="legal-section"><p>最終更新日: 2026-07-28</p>
+<h3>1. 規約の適用</h3>
+<p>本利用規約（以下「本規約」といいます）は、合同会社AllNew（以下「当社」といいます）が提供するiOSアプリケーション「NekoMeal」（日本語のApp Store表示名「NekoMeal」、以下「本アプリ」といいます）の利用条件を定めるものです。ユーザーは本規約に同意した上で本アプリを利用するものとします。</p>
+<h3>2. 利用開始と同意</h3>
+<p>ユーザーが本アプリをダウンロードし、インストールまたは利用を開始した時点で、本規約に同意したものとみなされます。本規約に同意しない場合、本アプリをご利用いただくことはできません。</p>
+<h3>3. 本アプリの概要と対応機器</h3>
+<p>本アプリは、App Store記載内容およびアプリ内説明に基づき、NekoMealは、見積書・請求書などの業務書類を作成・管理するためのアプリです。を提供するアプリケーションです。カメラまたは写真ライブラリを、ユーザーが明示的に選択した撮影、読み取り、記録補助のためにのみ使用します。撮影画像や選択画像は端末内で扱われ、プライバシーポリシーに明記した場合を除き、当社サーバーへ送信・保存しません。</p>
+<ul><li>対応デバイス: iOS 17.0以降を搭載したiPhone</li><li>対応OSや提供機能は、端末環境、地域、権限設定、プラットフォームポリシー等により異なる場合があります</li><li>本アプリは、ユーザーが自ら入力、記録、保存、管理する内容を補助するものであり、当社が当該内容の正確性や完全性を保証するものではありません</li></ul>
+<h3>4. プライバシーポリシーおよびデータの取り扱い</h3>
+<p>当社は、本アプリの利用に関連して取り扱う情報を別途定めるプライバシーポリシーに従って取り扱います。</p>
+<p>ユーザーが本アプリで作成、記録、保存、管理するデータについて、当社は以下を遵守します。</p>
+<ul><li>プライバシーポリシーで明示した場合を除き、ユーザーのデータを広告、マーケティング、または大量のデータを自動的に分析して傾向を見つける目的で使用しません</li><li>ユーザーのデータをデータブローカーや第三者に販売・提供しません</li><li>端末内処理を前提とする機能について、ユーザーのデータを当社が運用するサーバーへ送信・保存しません</li><li>当社が運用する外部サーバーまたは外部処理サービスへユーザーのデータを送信・保存しません</li></ul>
+<h3>5. 有料機能</h3>
+<p>本アプリの有料機能は App Store のアプリ内課金として提供される場合があります。</p>
+<ul><li>販売価格: App Store の購入画面に表示される価格、無料体験の有無・期間、更新条件が適用されます。</li><li>支払方法・時期: App Store が提供する決済手段によります。購入確定時または更新時に Apple から課金されます。</li><li>提供時期: 購入手続き完了後、対象の有料機能をすぐにご利用いただけます。</li><li>解約・返金: 解約、更新停止、返金等の手続きは Apple の App Store / Apple ID の管理画面および Apple の返金ポリシーに従います。</li><li>未成年者の利用: 未成年者が購入する場合、親権者の同意を得た上でご利用ください。</li></ul>
+<h3>6. 禁止事項</h3>
+<p>ユーザーは、以下の行為をしてはなりません。</p>
+<ul><li>本アプリの目的と異なる利用</li><li>法令または公序良俗に反する行為</li><li>第三者の権利、プライバシー、名誉、信用を侵害する行為</li><li>リバースエンジニアリング、解析、改変、複製、再配布</li><li>第三者のデータ、画像、音声、その他情報を無断で取得・記録・公開する行為</li><li>その他当社が不適切と判断する行為</li></ul>
+<h3>7. 重要情報に関する注意</h3>
+<p>本アプリは、ユーザーの日常的な記録、確認、整理、創作、または利便性向上を支援することを目的としたものです。専門的判断が必要な事項については、各分野の専門家にご相談ください。</p>
+<h3>8. 処理結果について</h3>
+<p>本アプリが入力、読み取り、変換、分類、加工、表示、同期、またはその他の自動処理を行う場合、その精度は100%ではありません。ユーザーは、処理結果を必要に応じて確認し、誤りがある場合は修正、削除、再実行等を行ってください。</p>
+<ul><li>認識精度や処理結果は、端末、OS、設定、権限、通信状態、入力品質、撮影条件、利用環境等により変動します</li><li>本アプリの表示や処理結果は、最終判断の代替となるものではありません</li><li>誤った結果に基づく利用について、当社は法令で認められる範囲で責任を負いません</li></ul>
+<h3>9. 知的財産権</h3>
+<p>本アプリに関する著作権その他の知的財産権は、当社または正当な権利を有する第三者に帰属します。本規約により、ユーザーへ本アプリまたは関連資料に関する権利が移転するものではありません。</p>
+<h3>10. 免責事項</h3>
+<p>当社は、本アプリの機能が中断なく動作すること、処理結果、表示内容、保存結果、同期結果等が常に正確であることを保証しません。</p>
+<p>当社は、ユーザーの端末、OS、Appleのサービス、ネットワーク、外部サービス、権限設定、またはユーザーの操作に起因する損害について責任を負いません。</p>
+<p>当社が損害賠償責任を負う場合でも、当社の故意または重過失がある場合を除き、当社の責任は通常かつ直接の損害に限られます。なお、消費者契約法その他の強行法規により制限される範囲では本項は適用されません。</p>
+<h3>11. 規約の変更</h3>
+<p>当社は、必要に応じて本規約を変更することがあります。変更後の規約は、当社サイト、本アプリ内、またはその他合理的な方法で掲示された時点から効力を生じます。重要な変更については、合理的な方法により事前または事後に通知するよう努めます。</p>
+<h3>12. 準拠法・管轄</h3>
+<p>本規約は日本法に準拠します。本アプリまたは本規約に関して紛争が生じた場合、法令に別段の定めがある場合を除き、東京地方裁判所を第一審の専属的合意管轄裁判所とします。</p>
+<h3>13. 多言語版について</h3>
+<p>本利用規約は日本語を正文とします。他言語版との間に矛盾がある場合、日本語版を優先します。ただし、この規定は各居住国・地域の消費者保護法その他の強行法規に基づくユーザーの権利を制限するものではありません。</p></div></section>
+    <section id="terms-en" class="section" data-lang="en"><div class="section-header"><div class="section-icon">📜</div><div><div class="section-title">Terms of Service</div><div class="section-subtitle">Conditions for using the app</div></div></div><div class="legal-section"><p>Last Updated: 2026-07-28</p>
+<h3>1. Acceptance of Terms</h3>
+<p>These Terms of Service (&quot;Terms&quot;) govern your use of the iOS application &quot;NekoMeal&quot; (Japanese App Store display name: &quot;NekoMeal&quot;; the &quot;App&quot;) provided by AllNew LLC (&quot;we,&quot; &quot;us,&quot; or &quot;our&quot;). By using the App, you agree to these Terms.</p>
+<h3>2. Agreement to Terms</h3>
+<p>By downloading, installing, or using the App, you agree to be bound by these Terms. If you do not agree, do not use the App.</p>
+<h3>3. App Description and Compatibility</h3>
+<p>The App provides NekoMeal helps create and manage estimates, invoices, and related business documents. as described in the App Store listing and in-app documentation. The App uses the camera or photo library only when you explicitly choose to capture, read, or attach records. Captured or selected images are handled on device and are not transmitted to or stored on our servers unless expressly described in this Privacy Policy.</p>
+<ul><li>Supported devices: iPhone running iOS 17.0 or later</li><li>Supported OS versions and available features may vary depending on device environment, region, permissions, and platform policies</li><li>The App assists content, records, review, organization, creation, or convenience based on user input, and we do not guarantee the accuracy or completeness of user-provided content</li></ul>
+<h3>4. Privacy Policy and Data Handling</h3>
+<p>Your use of the App is also governed by our Privacy Policy.</p>
+<p>For data you create, capture, save, or manage in the App, we commit to the following:</p>
+<ul><li>We do not use your data for advertising, marketing, or data mining purposes unless expressly described in the Privacy Policy</li><li>We do not sell or provide your data to data brokers or third parties</li><li>For features designed to work on device, we do not transmit or store your data on servers operated by us</li><li>We do not transmit or store your data on servers operated by us or external processing services</li></ul>
+<h3>5. Paid Features</h3>
+<p>Paid features may be offered through App Store in-app purchase.</p>
+<ul><li>Price: The price, free-trial availability and duration, and renewal conditions shown in the App Store purchase sheet apply.</li><li>Payment method and timing: Payment is made through App Store payment methods. Apple charges you when purchase or renewal is confirmed.</li><li>Delivery: Paid features are available immediately after purchase completion.</li><li>Cancellation and refunds: Cancellation, renewal management, and refund procedures follow Apple&#x27;s App Store / Apple ID management flow and Apple&#x27;s refund policy.</li><li>Minors: Minors must obtain parental consent before purchasing.</li></ul>
+<h3>6. Prohibited Activities</h3>
+<p>You must not:</p>
+<ul><li>Use the App for purposes other than its intended purpose</li><li>Violate any laws or third-party rights</li><li>Infringe any third party&#x27;s privacy, reputation, credit, or intellectual property rights</li><li>Reverse engineer, decompile, modify, copy, or redistribute the App</li><li>Capture, record, publish, or otherwise use another person&#x27;s data, images, audio, or other information without permission</li><li>Engage in any other conduct we reasonably determine to be inappropriate</li></ul>
+<h3>7. Important Information Disclaimer</h3>
+<p>The App is intended to support everyday records, review, organization, creation, or convenience. Please consult an appropriate professional for matters requiring expert judgment.</p>
+<h3>8. Processing Results</h3>
+<p>If the App performs capture, recognition, conversion, classification, editing, display, syncing, or other automated processing, accuracy is not 100%. You should review the results where necessary and correct, delete, or rerun processing if results are inaccurate.</p>
+<ul><li>Recognition accuracy and processing results may vary depending on device, OS, settings, permissions, network conditions, input quality, shooting conditions, and surrounding environment</li><li>App outputs and processing results are not a substitute for final human judgment</li><li>We are not liable for use based on inaccurate results to the extent permitted by law</li></ul>
+<h3>9. Intellectual Property</h3>
+<p>All intellectual property rights in the App and related materials belong to us or our licensors. These Terms do not transfer any rights in the App or related materials to you.</p>
+<h3>10. Disclaimer of Warranties</h3>
+<p>We do not guarantee that the App will operate without interruption, or that processing results, displayed content, saved content, syncing, or any other App output will always be accurate.</p>
+<p>We are not liable for damages arising from your device, OS, Apple services, network, external services, permission settings, or your operation of the App.</p>
+<p>Where we are liable, our liability is limited to ordinary and direct damages, except in cases of willful misconduct or gross negligence. This clause does not apply to the extent restricted by the Consumer Contract Act or other mandatory laws.</p>
+<h3>11. Changes to Terms</h3>
+<p>We may amend these Terms as necessary. Amended Terms take effect when posted on our website, in the App, or by other reasonable means. For material changes, we will endeavor to provide notice through reasonable means.</p>
+<h3>12. Governing Law and Jurisdiction</h3>
+<p>These Terms are governed by the laws of Japan. Unless mandatory local law provides otherwise, disputes related to the App or these Terms are subject to the exclusive jurisdiction of the Tokyo District Court as the court of first instance.</p>
+<h3>13. Translations</h3>
+<p>The Japanese version of these Terms is the authoritative text. If any translated version conflicts with the Japanese version, the Japanese version prevails. This does not limit rights granted to users under mandatory consumer-protection laws or other non-waivable regulations in their jurisdiction.</p></div></section>
+    <section id="oss-ja" class="section" data-lang="ja"><div class="section-header"><div class="section-icon">📦</div><div><div class="section-title">3rd Party Licensing Notice</div><div class="section-subtitle">Open Source Software notices</div></div></div><div class="legal-section"><h3>3rd Party Licensing Notice</h3><h4>オープンソースソフトウェアに関するお知らせ</h4><p>本製品には、オープンソースライセンスに基づき提供されるソフトウェアが含まれる場合があります。本製品に適用される利用規約と、当該Open Source Softwareに適用されるオープンソースライセンスの内容が矛盾する場合、当該Open Source Softwareについてはオープンソースライセンスが優先します。</p><p>一部のオープンソースライセンスでは、ソースコードの写しを入手する権利が認められています。適用ライセンス上必要な場合、AllNewはこのページまたはこのページに記載されたサポート窓口を通じて、対応するソースコードの入手方法を提供します。</p><h4>現在の確認結果</h4><p>このバージョンの現在の確認では、第三者のOpen Source Softwareパッケージは検出されていません。将来のバージョンでOpen Source Softwareを含める場合、該当する著作権表示、ライセンス、ソースコード提供方法をこのセクションに掲載します。</p><p>Apple SDK（Appleが提供する開発用プログラム部品）およびApple純正フレームワークは本表示の第三者OSSには含めず、Appleの各規約に従います。</p><p class="muted">確認日: 2026-07-28</p></div></section>
+    <section id="oss-en" class="section" data-lang="en"><div class="section-header"><div class="section-icon">📦</div><div><div class="section-title">3rd Party Licensing Notice</div><div class="section-subtitle">Open Source Software notices</div></div></div><div class="legal-section"><h3>3rd Party Licensing Notice</h3><h4>Open Source Software Notice</h4><p>This product may include software provided under open source licenses. If the terms for this product conflict with the applicable open source license for such software, the open source license controls for that software.</p><p>If a license requires source code availability, contact the support address listed on this page and identify the product name and version where possible.</p><h4>Current Review Result</h4><p>No third-party Open Source Software package is currently detected for this version. If future versions include Open Source Software, applicable copyright notices, licenses, and source-code access instructions will be posted in this section.</p><p>Apple SDKs (Apple-provided development toolkits) and Apple-provided frameworks are not included in this third-party OSS notice and are governed by Apple's terms.</p><p class="muted">Review date: 2026-07-28</p></div></section>
+    <section id="commercial-ja" class="section" data-lang="ja"><div class="commercial-accordion"><button class="commercial-header" type="button" aria-expanded="false"><div class="section-header"><div class="section-icon">🏢</div><div><div class="section-title">特定商取引法に基づく表記</div><div class="section-subtitle">販売事業者情報</div></div></div><span class="commercial-toggle" aria-hidden="true">+</span></button><div class="commercial-content"><dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>販売事業者</dt><dd>合同会社AllNew</dd></div><div class="contact-item"><dt>運営統括責任者</dt><dd>植野 正徳</dd></div><div class="contact-item"><dt>所在地</dt><dd>〒107-0052 東京都港区赤坂8-4-14 青山タワープレイス8F</dd></div><div class="contact-item"><dt>電話番号</dt><dd>請求があれば遅滞なく開示します（特定商取引法第11条ただし書に基づく省略表示）</dd></div><div class="contact-item"><dt>取引条件</dt><dd>販売価格、支払方法、提供時期、解約・返金等は、本ページの「利用規約」内の有料機能の項目および App Store の購入画面に表示します。</dd></div></dl></div></div></section>
+    <section id="commercial-en" class="section" data-lang="en"><div class="commercial-accordion"><button class="commercial-header" type="button" aria-expanded="false"><div class="section-header"><div class="section-icon">🏢</div><div><div class="section-title">Seller Information</div><div class="section-subtitle">Specified Commercial Transactions Act (Japan)</div></div></div><span class="commercial-toggle" aria-hidden="true">+</span></button><div class="commercial-content"><dl class="contact-details" style="margin-top: 16px; padding-top: 0; border-top: none;"><div class="contact-item"><dt>Seller</dt><dd>AllNew LLC</dd></div><div class="contact-item"><dt>Representative</dt><dd>Masanori Ueno</dd></div><div class="contact-item"><dt>Address</dt><dd>Aoyama Tower Place 8F, 8-4-14 Akasaka, Minato-ku, Tokyo 107-0052, Japan</dd></div><div class="contact-item"><dt>Phone</dt><dd>Disclosed without delay upon request where omission is permitted under the proviso to Article 11 of the Japanese Specified Commercial Transactions Act.</dd></div><div class="contact-item"><dt>Transaction Terms</dt><dd>Price, payment method, delivery timing, cancellation, and refund terms are shown in the Paid Features section of these Terms and in the App Store purchase sheet.</dd></div></dl></div></div></section>
+    <section id="contact-ja" class="section" data-lang="ja"><div class="contact-card"><h2>お問い合わせ</h2><!--email_off--><a href="mailto:app-support@allnew.work?subject=NekoMeal%20%3A%20" class="contact-email">✉️ メールを送る</a><!--/email_off--><a href="https://apps.allnew.work/feedback/?app=nekomeal" class="contact-email" style="margin:12px 0 0 12px">💬 ご意見・ご要望を送る（POIPOI-STUDIO）</a><dl class="contact-details contact-details-top" style="border-bottom: none;"><div class="contact-item"><dt>受付時間</dt><dd>平日 11:00〜15:00</dd></div><div class="contact-item"><dt>対応言語</dt><dd>日本語・英語</dd></div></dl></div></section>
+    <section id="contact-en" class="section" data-lang="en"><div class="contact-card"><h2>Contact Us</h2><!--email_off--><a href="mailto:app-support@allnew.work?subject=NekoMeal%20%3A%20" class="contact-email">✉️ Send Email</a><!--/email_off--><a href="https://apps.allnew.work/feedback/?app=nekomeal" class="contact-email" style="margin:12px 0 0 12px">💬 Share Feedback (POIPOI-STUDIO)</a><dl class="contact-details contact-details-top" style="border-bottom: none;"><div class="contact-item"><dt>Hours</dt><dd>Weekdays 11:00-15:00 JST</dd></div><div class="contact-item"><dt>Languages</dt><dd>Japanese, English</dd></div></dl></div></section>
+  </main>
+
+  <script>
+    function toggleLangMenu() {
+      const dropdown = document.getElementById('langDropdown');
+      dropdown.classList.toggle('open');
+      const button = dropdown.querySelector('.lang-btn');
+      button.setAttribute('aria-expanded', dropdown.classList.contains('open') ? 'true' : 'false');
+    }
+    function setLang(lang) {
+      document.body.classList.toggle('lang-en', lang === 'en');
+      document.documentElement.lang = lang;
+      document.getElementById('currentLang').textContent = lang === 'ja' ? '日本語' : 'English';
+      document.querySelectorAll('.lang-option').forEach(function(option) {
+        option.classList.toggle('active', option.dataset.langOption === lang);
+      });
+      const dropdown = document.getElementById('langDropdown');
+      dropdown.classList.remove('open');
+      dropdown.querySelector('.lang-btn').setAttribute('aria-expanded', 'false');
+      try { localStorage.setItem('allnewLegalLang', lang); } catch (_) {}
+    }
+    document.addEventListener('click', function(event) {
+      const dropdown = document.getElementById('langDropdown');
+      if (dropdown && !dropdown.contains(event.target)) {
+        dropdown.classList.remove('open');
+        dropdown.querySelector('.lang-btn').setAttribute('aria-expanded', 'false');
+      }
+      const faq = event.target.closest('.faq-question');
+      if (faq) {
+        faq.closest('.faq-item').classList.toggle('open');
+        return;
+      }
+      const header = event.target.closest('.commercial-header');
+      if (!header) return;
+      const accordion = header.closest('.commercial-accordion');
+      const isOpen = accordion.classList.toggle('open');
+      header.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    });
+    function checkCommercialAnchor() {
+      if (!location.hash || !location.hash.includes('commercial')) return;
+      document.querySelectorAll('.commercial-accordion').forEach(function(accordion) {
+        accordion.classList.add('open');
+        const header = accordion.querySelector('.commercial-header');
+        if (header) header.setAttribute('aria-expanded', 'true');
+      });
+    }
+    const params = new URLSearchParams(location.search);
+    const requested = params.get('lang') || (navigator.language || '').slice(0, 2);
+    setLang(requested === 'ja' ? 'ja' : 'en');
+    checkCommercialAnchor();
+    window.addEventListener('hashchange', checkCommercialAnchor);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
NekoMeal's in-app Terms / Privacy / 特定商取引法 / Support rows link to `https://apps.allnew.work/nekomeal`, so the page must exist before submission or legal-surface verification.

Rendered by `ios-app-factory-v5 scripts/v5_legal_support_site.py` from the shared v4.7 template — output byte-identical to the v4.7 renderer, reader-grade, no unresolved placeholders. Sections present: FAQ, Privacy, Terms, Tokusho, OSS, Contact (ja/en).

Verified before publishing: no placeholder leaks, no other app's name in the page, all five required section anchors (`faq-ja`, `privacy-ja`, `terms-ja`, `commercial-ja`, `contact-ja`).

Deliberately **not** added to `app-data.js` — NekoMeal is unreleased and must not appear in the public catalog yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)