### PR TITLE
Restore PetPlay Relay legal deep links

### DIFF
--- a/petplayrelay/index.html
+++ b/petplayrelay/index.html
@@ -634,6 +634,14 @@
     const requested = params.get('lang') || (navigator.language || '').slice(0, 2);
     setLang(requested === 'ja' ? 'ja' : 'en');
     checkCommercialAnchor();
+    function restoreHashAnchor() {
+      if (!location.hash) return;
+      const target = document.getElementById(location.hash.slice(1));
+      if (target) target.scrollIntoView();
+    }
+    requestAnimationFrame(function() {
+      requestAnimationFrame(restoreHashAnchor);
+    });
     window.addEventListener('hashchange', checkCommercialAnchor);
   </script>
 </body>


### PR DESCRIPTION
## Summary
- re-apply the requested hash anchor after the language layout is initialized
- keep Settings and ASC URLs such as #terms-ja on the requested legal section in WebKit

## Verification
- v5 legal template tests: 11 passed
- regenerated hosted page report: passed, reader-grade, reference output identity passed
- local HTML parser and anchor token checks passed